### PR TITLE
Add ghc flag correct error with C preprocessor on macOS

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -102,6 +102,7 @@ ghc-options:
   - -j
   - -static
   - -fwrite-ide-info
+  - -optP-Wno-nonportable-include-path
 
 when:
   condition: flag(incomplete-error)


### PR DESCRIPTION
```
juvix           > /Users/cyberglot/workspace/WORK/juvix/<built-in>:15:10: error:
juvix           >      warning: non-portable path to file '".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/Juvix/autogen/cabal_macros.h"'; specified path differs in case from file name on disk [-Wnonportable-include-path]
juvix           > #include ".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/juvix/autogen/cabal_macros.h"
juvix           >          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
juvix           >          ".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/Juvix/autogen/cabal_macros.h"
juvix           > 1 warning generated.
```

I keep having this error, so I finally found that we can add a ghc flag to fix it.