### PR TITLE
fix typo in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ UNAME := $(shell uname)
 
 ifeq ($(UNAME), Darwin)
 	THREADS := $(shell sysctl -n hw.logicalcpu)
-else ifeq($(UNAME), Linux)
+else ifeq ($(UNAME), Linux)
 	THREADS := $(shell nproc)
 else
 	THREADS := $(shell echo %NUMBER_OF_PROCESSORS%)


### PR DESCRIPTION
It seems like the space after `ifeq` is mandatory, otherwise I get an error:

```
Makefile:7: extraneous text after 'else' directive
```