### PR TITLE
Single definitions down the pipeline!

### DIFF
--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1369,6 +1369,26 @@ Calculate mutually-recursive groups of definitions.
   + [[NameSymbol]]
 ***** Contextify
 ****** ResolveOpenInfo
+- This module is responsible for adding the reverse open
+  information to the context, along with the alias map of what
+  symbols get qualified to what module
+- This module accepts a list of =PreQualified= which talks
+  about
+  1. The explicit module itself
+  2. Any opens this module does
+  3. Any modules defined in this module as to have implicit imports
+- Currently the most complicated part of this module is the resolve
+  section that creates an =OpenMap=
+  + This code is responsible for taking in all the opens and
+    properly storing them fully qualified.
+  + This has to try to open as much as possible as we could have
+    =open Michelson= =open Prelude=, in which Michelson is inside
+    of prelude so it can't be resolved right away. This way can
+    lead to ambiguities if it does exist so one has to be a bit
+    careful opening in this way!
+- The other bits of code are stand alone algorithms for filling in
+  the reverse map and the qualification from that point
+  forward.... these are thankfully quite straight forward
 - _Relies on_
   + [[Core/Common/Context]]
   + [[NameSpace]]

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1385,6 +1385,13 @@ Calculate mutually-recursive groups of definitions.
   + [[Library]]
   + [[NameSymbol]]
 ***** Contextify
+****** ResolveOpenInfo
+- _Relies on_
+  + [[Core/Common/Context]]
+  + [[Common/Open]]
+  + [[Library]]
+  + [[HashMap]]
+  + [[NameSymbol]]
 ****** Transform <<Contextify/Transform>>
 - _Relies on_
   + [[Core/Common/Context]]

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -591,18 +591,6 @@ Types to support partial application and polymorphic primitives.
   + [[HashMap]]
   + [[NameSymbol]]
   + [[Usage]]
-******* RecGroups
-Calculate mutually-recursive groups of definitions.
-- _Relies on_
-  + [[RecGroups/Types]]
-  + [[Context/Types]]
-  + [[NameSpace]]
-  + [[Library]]
-******** Types <<RecGroups/Types>>
-- _Relies on_
-  + [[Context/Types]]
-  + [[Library]]
-  + [[NameSymbol]]
 ***** Erased
 - _Relies on_
   + [[Erased/Evaluator]]

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1560,6 +1560,7 @@ Calculate mutually-recursive groups of definitions.
 - _Relies on_
   + [[Core/Common/Context]]
   + [[NameSpace]]
+  + [[ResolveOpenInfo]]
   + [[ModuleOpen/Environment]]
   + [[ModuleOpen/Types]]
   + [[RemoveDo/Types]]

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1301,7 +1301,6 @@ Can be added to via core translation
 - Every hash in the code base should use this, except when it needs
   to compare keys by the =Ordering= metric instead.
 ***** NameSymbol
-<<<<<<< HEAD
 - _Relies on_
   + [[Library]]
   + [[Lexer]]
@@ -1311,12 +1310,6 @@ Can be added to via core translation
   + [[Library]]
 ***** Symbol
 ****** Lexer
-=======
-- _Relies on_
-  + [[Library]]
-***** PrettyPrint
-***** Usage
->>>>>>> a94cafd (updated to have inNameSpace and simplify the switchNameSPace function)
 - _Relies on_
   + [[Library]]
 ** test

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1313,6 +1313,7 @@ Can be added to via core translation
 - Every hash in the code base should use this, except when it needs
   to compare keys by the =Ordering= metric instead.
 ***** NameSymbol
+<<<<<<< HEAD
 - _Relies on_
   + [[Library]]
   + [[Lexer]]
@@ -1322,6 +1323,12 @@ Can be added to via core translation
   + [[Library]]
 ***** Symbol
 ****** Lexer
+=======
+- _Relies on_
+  + [[Library]]
+***** PrettyPrint
+***** Usage
+>>>>>>> a94cafd (updated to have inNameSpace and simplify the switchNameSPace function)
 - _Relies on_
   + [[Library]]
 ** test

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1902,3 +1902,13 @@ Calculate mutually-recursive groups of definitions.
   + [[ModuleOpen/Types]]
   + [[Library]]
   + [[HashMap]]
+***** Resolve
+- _Relies on_
+  + [[Core/Common/Context]]
+  + [[Core/Common/Context]]
+  + [[NameSpace]]
+  + [[ResolveOpenInfo]]
+  + [[ModuleOpen/Environment]]
+  + [[ModuleOpen/Types]]
+  + [[Library]]
+  + [[HashMap]]

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1909,6 +1909,5 @@ Calculate mutually-recursive groups of definitions.
   + [[NameSpace]]
   + [[ResolveOpenInfo]]
   + [[ModuleOpen/Environment]]
-  + [[ModuleOpen/Types]]
   + [[Library]]
   + [[HashMap]]

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -591,6 +591,18 @@ Types to support partial application and polymorphic primitives.
   + [[HashMap]]
   + [[NameSymbol]]
   + [[Usage]]
+******* RecGroups
+Calculate mutually-recursive groups of definitions.
+- _Relies on_
+  + [[RecGroups/Types]]
+  + [[Context/Types]]
+  + [[NameSpace]]
+  + [[Library]]
+******** Types <<RecGroups/Types>>
+- _Relies on_
+  + [[Context/Types]]
+  + [[Library]]
+  + [[NameSymbol]]
 ***** Erased
 - _Relies on_
   + [[Erased/Evaluator]]

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1388,6 +1388,7 @@ Calculate mutually-recursive groups of definitions.
 ****** ResolveOpenInfo
 - _Relies on_
   + [[Core/Common/Context]]
+  + [[NameSpace]]
   + [[Common/Open]]
   + [[Library]]
   + [[HashMap]]
@@ -1515,6 +1516,7 @@ Calculate mutually-recursive groups of definitions.
 - _Relies on_
   + [[Core/Common/Context]]
   + [[NameSpace]]
+  + [[ResolveOpenInfo]]
   + [[FrontendContextualise/Environment]]
   + [[ModuleOpen/Types]]
   + [[RemoveDo/Types]]

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1383,6 +1383,7 @@ Calculate mutually-recursive groups of definitions.
 - _Relies on_
   + [[Core/Common/Context]]
   + [[NameSpace]]
+  + [[Common/Open]]
   + [[Library]]
   + [[NameSymbol]]
 ***** Contextify

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1368,6 +1368,7 @@ Calculate mutually-recursive groups of definitions.
   2. =InfixPrecedence=
 - _Relies on_
   + [[Core/Common/Context]]
+  + [[ResolveOpenInfo]]
   + [[Contextify/Transform]]
   + [[Contextify/Types]]
   + [[InfixPrecedence/Environment]]
@@ -1516,6 +1517,7 @@ Calculate mutually-recursive groups of definitions.
 - _Relies on_
   + [[Core/Common/Context]]
   + [[NameSpace]]
+  + [[ResolveOpenInfo]]
   + [[ResolveOpenInfo]]
   + [[FrontendContextualise/Environment]]
   + [[ModuleOpen/Types]]
@@ -1895,6 +1897,7 @@ Calculate mutually-recursive groups of definitions.
 - _Relies on_
   + [[Core/Common/Context]]
   + [[NameSpace]]
+  + [[ResolveOpenInfo]]
   + [[ModuleOpen/Environment]]
   + [[ModuleOpen/Types]]
   + [[Library]]

--- a/library/Core/src/Juvix/Core/Common/Context.hs
+++ b/library/Core/src/Juvix/Core/Common/Context.hs
@@ -529,6 +529,8 @@ lookupGen ::
 lookupGen extraLookup nameSymb t =
   let recurse _ Nothing =
         Nothing
+      recurse [] (Just CurrentNameSpace) =
+        Just (Record (t ^. _currentNameSpace))
       recurse [] x =
         x
       recurse (x : xs) (Just (Record record)) =

--- a/library/Core/src/Juvix/Core/Common/Context.hs
+++ b/library/Core/src/Juvix/Core/Common/Context.hs
@@ -102,7 +102,7 @@ persistDefinition T {reverseLookup} moduleName name =
           lookd <- STM.lookup name symbolMap
           case lookd of
             Nothing ->
-              STM.insert (SymInfo NotUsed Explicit moduleName) name symbolMap
+              STM.insert (SymInfo NotUsed moduleName) name symbolMap
             -- TODO ∷ we may change behavior here based on implicit vs explicit
             Just SymInfo {} -> pure ()
     Nothing -> pure (Lib.Right ())

--- a/library/Core/src/Juvix/Core/Common/Context.hs
+++ b/library/Core/src/Juvix/Core/Common/Context.hs
@@ -102,7 +102,7 @@ persistDefinition T {reverseLookup} moduleName name =
           lookd <- STM.lookup name symbolMap
           case lookd of
             Nothing ->
-              STM.insert (SymInfo NotUsed moduleName) name symbolMap
+              STM.insert (SymInfo NotUsed Explicit moduleName) name symbolMap
             -- TODO ∷ we may change behavior here based on implicit vs explicit
             Just SymInfo {} -> pure ()
     Nothing -> pure (Lib.Right ())

--- a/library/Core/src/Juvix/Core/Common/Context.hs
+++ b/library/Core/src/Juvix/Core/Common/Context.hs
@@ -318,8 +318,10 @@ addTopNameToSngle :: IsString a => NonEmpty a -> NonEmpty a
 addTopNameToSngle (x :| []) = topLevelName :| [x]
 addTopNameToSngle xs = xs
 
-addTopName :: IsString a => NonEmpty a -> NonEmpty a
-addTopName (x :| xs) = topLevelName :| (x : xs)
+addTopName :: (IsString a, Eq a) => NonEmpty a -> NonEmpty a
+addTopName (x :| xs)
+  | topLevelName == x = x :| xs
+  | otherwise = topLevelName :| (x : xs)
 
 removeTopName :: (Eq a, IsString a) => NonEmpty a -> NonEmpty a
 removeTopName (top :| x : xs)

--- a/library/Core/src/Juvix/Core/Common/Context/Types.hs
+++ b/library/Core/src/Juvix/Core/Common/Context/Types.hs
@@ -89,22 +89,17 @@ type SymbolMap = STM.Map Symbol SymbolInfo
 
 type ReverseLookup = HashMap.T NameSymbol.T [WhoUses]
 
+-- Note ∷ we don't store the implicit explicit open nature of the symbol
+-- this can be found by querying the reverse map and seeing there
+-- this is sadly O(n) right now... but can be made faster in the future
 data SymbolInfo
   = SymInfo
       { -- | used notes if the symbol is used and if so in what
         used :: UsedIn,
-        -- | Used to tell if the module was implicitly or explicitly opened
-        open :: Open,
         -- | mod is the module where the symbol is coming from
         mod :: NameSymbol.T
       }
   deriving (Show, Eq, Generic)
-
-data Open
-  = Implicit
-  | Explicit
-  deriving (Show, Eq, Ord)
-
 
 data UsedIn = Func [Symbol] | NotUsed | Yes deriving (Show, Eq, Generic)
 

--- a/library/Core/src/Juvix/Core/Common/Context/Types.hs
+++ b/library/Core/src/Juvix/Core/Common/Context/Types.hs
@@ -93,10 +93,18 @@ data SymbolInfo
   = SymInfo
       { -- | used notes if the symbol is used and if so in what
         used :: UsedIn,
+        -- | Used to tell if the module was implicitly or explicitly opened
+        open :: Open,
         -- | mod is the module where the symbol is coming from
         mod :: NameSymbol.T
       }
   deriving (Show, Eq, Generic)
+
+data Open
+  = Implicit
+  | Explicit
+  deriving (Show, Eq, Ord)
+
 
 data UsedIn = Func [Symbol] | NotUsed | Yes deriving (Show, Eq, Generic)
 

--- a/library/Translate/package.yaml
+++ b/library/Translate/package.yaml
@@ -15,6 +15,7 @@ dependencies:
 - frontend
 - extensible-data
 - unordered-containers
+- stm-containers
 - lens
 - containers
 - dlist

--- a/library/Translate/package.yaml
+++ b/library/Translate/package.yaml
@@ -16,6 +16,7 @@ dependencies:
 - extensible-data
 - unordered-containers
 - stm-containers
+- list-t
 - lens
 - containers
 - dlist

--- a/library/Translate/src/Juvix/FrontendContextualise.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise.hs
@@ -11,6 +11,7 @@ module Juvix.FrontendContextualise
 where
 
 import qualified Juvix.Core.Common.Context as Context
+import qualified Juvix.FrontendContextualise.Contextify.ResolveOpenInfo as ResolveOpen
 import qualified Juvix.FrontendContextualise.Contextify.Transform as Contextify
 import qualified Juvix.FrontendContextualise.Contextify.Types as Contextify
 import qualified Juvix.FrontendContextualise.InfixPrecedence.Environment as Infix
@@ -52,7 +53,7 @@ contextualize init = do
 
 contextify ::
   NonEmpty (NameSymbol.T, [Initial.TopLevel]) ->
-  IO (Either Context.PathError (Contextify.Context, [Module.PreQualified]))
+  IO (Either Context.PathError (Contextify.Context, [ResolveOpen.PreQualified]))
 contextify t@((sym, _) :| _) = do
   emptyCtx <- Context.empty sym
   runM $
@@ -64,16 +65,16 @@ addTop = first (NameSymbol.cons Context.topLevelName)
 -- we get the opens
 resolveOpens ::
   (MonadIO m, HasThrow "left" Context.PathError m) =>
-  (Contextify.Context, [Module.PreQualified]) ->
+  (Contextify.Context, [ResolveOpen.PreQualified]) ->
   (Context.NameSymbol, [Initial.TopLevel]) ->
-  m (Contextify.Context, [Module.PreQualified])
+  m (Contextify.Context, [ResolveOpen.PreQualified])
 resolveOpens (ctx', openList) (sym, xs) = do
   ctx <- liftIO (Contextify.run ctx' (sym, xs))
   case ctx of
     Right Contextify.P {ctx, opens, modsDefined} ->
       pure
         ( ctx,
-          Module.Pre
+          ResolveOpen.Pre
             { opens,
               explicitModule = sym,
               implicitInner = modsDefined

--- a/library/Translate/src/Juvix/FrontendContextualise/Contextify/ResolveOpenInfo.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/Contextify/ResolveOpenInfo.hs
@@ -1,0 +1,15 @@
+module Juvix.FrontendContextualise.Contextify.ResolveOpenInfo where
+
+import Juvix.Library
+import qualified Juvix.Library.NameSymbol as NameSymbol
+
+
+data PreQualified
+  = Pre
+      { opens :: [NameSymbol.T],
+        implicitInner :: [NameSymbol.T],
+        explicitModule :: NameSymbol.T
+      }
+  deriving (Show, Eq)
+
+

--- a/library/Translate/src/Juvix/FrontendContextualise/Contextify/ResolveOpenInfo.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/Contextify/ResolveOpenInfo.hs
@@ -1,8 +1,12 @@
 module Juvix.FrontendContextualise.Contextify.ResolveOpenInfo where
 
+import Control.Lens hiding ((|>))
+import qualified Juvix.Core.Common.Context as Context
+import qualified Juvix.Core.Common.Open as Open
 import Juvix.Library
+import qualified Juvix.Library.HashMap as HashMap
 import qualified Juvix.Library.NameSymbol as NameSymbol
-
+import qualified StmContainers.Map as STM
 
 data PreQualified
   = Pre
@@ -12,4 +16,68 @@ data PreQualified
       }
   deriving (Show, Eq)
 
+data Error
+  = UnknownModule NameSymbol.T
+  | CantResolveModules [NameSymbol.T]
+  deriving (Show, Eq)
 
+type RunM =
+  ExceptT Error IO
+
+newtype M a = M (RunM a)
+  deriving (Functor, Applicative, Monad, MonadIO)
+  deriving (HasThrow "left" Error) via MonadError RunM
+
+runM :: M a -> IO (Either Error a)
+runM (M a) = runExceptT a
+
+run ::
+  Context.T term ty sumRep ->
+  [PreQualified] ->
+  IO (Either Error (Context.T term ty sumRep))
+run ctx qualifieds = do
+  resolved <- resolve ctx qualifieds
+  case resolved of
+    Right reverse -> pure (Right ctx {Context.reverseLookup = reverse})
+    Left error -> pure (Left error)
+
+resolve :: Context.T a b c -> [PreQualified] -> IO (Either Error Context.ReverseLookup)
+resolve ctx = runM . foldM (resolveSingle ctx) mempty
+
+resolveSingle ::
+  (HasThrow "left" Error m, MonadIO m) =>
+  Context.T a b c ->
+  Context.ReverseLookup ->
+  PreQualified ->
+  m Context.ReverseLookup
+resolveSingle ctx reverseLookup Pre {opens, implicitInner, explicitModule} =
+  case nameSpace of
+    Nothing ->
+      throw @"left" (UnknownModule explicitModule)
+    Just ctx -> do
+      let symbolMap =
+            ctx ^. Context._currentNameSpace . Context.qualifiedMap
+          updateRevLook impExplict existing =
+            let whousesInfo =
+                  Context.Who {impExplict, modName = explicitModule, symbolMap}
+             in case existing of
+                  Nothing -> Just [whousesInfo]
+                  Just es -> Just (whousesInfo : es)
+          alterUpdate = HashMap.alter . updateRevLook
+          newResolve =
+            foldr (alterUpdate Open.Explicit) reverseLookup opens
+              |> \lookup ->
+                foldr (alterUpdate Open.Implicit) lookup implicitInner
+      -- TODO ∷ put logic that mutates the local opens here
+      undefined
+      pure newResolve
+  where
+    nameSpace = Context.inNameSpace explicitModule ctx
+
+grabQualifiedMap ::
+  HasThrow "left" Error m => Context.T a b c -> NameSymbol.T -> m Context.SymbolMap
+grabQualifiedMap ctx name =
+  case Context.extractValue <$> Context.lookup name ctx of
+    Just (Context.Record Context.Rec {recordQualifiedMap}) ->
+      pure recordQualifiedMap
+    _ -> throw @"left" (UnknownModule (Context.qualifyName name ctx))

--- a/library/Translate/src/Juvix/FrontendContextualise/Contextify/ResolveOpenInfo.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/Contextify/ResolveOpenInfo.hs
@@ -1,3 +1,24 @@
+-- |
+-- - This module is responsible for adding the reverse open
+--   information to the context, along with the alias map of what
+--   symbols get qualified to what module
+-- - This module accepts a list of =PreQualified= which talks
+--   about
+--   1. The explicit module itself
+--   2. Any opens this module does
+--   3. Any modules defined in this module as to have implicit imports
+-- - Currently the most complicated part of this module is the resolve
+--   section that creates an =OpenMap=
+--   + This code is responsible for taking in all the opens and
+--     properly storing them fully qualified.
+--   + This has to try to open as much as possible as we could have
+--     =open Michelson= =open Prelude=, in which Michelson is inside
+--     of prelude so it can't be resolved right away. This way can
+--     lead to ambiguities if it does exist so one has to be a bit
+--     careful opening in this way!
+-- - The other bits of code are stand alone algorithms for filling in
+--   the reverse map and the qualification from that point
+--   forward.... these are thankfully quite straight forward
 module Juvix.FrontendContextualise.Contextify.ResolveOpenInfo where
 
 import Control.Lens hiding ((|>))

--- a/library/Translate/src/Juvix/FrontendContextualise/Contextify/ResolveOpenInfo.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/Contextify/ResolveOpenInfo.hs
@@ -189,7 +189,7 @@ grabQualifiedMap ctx name =
 
 -- | @removeRedundantQualifieds@ takes a qualified and removes any
 -- redundant imports it may contain
-removeRedundantQualifieds Pre {opens, implicitInner, explicitModule} = undefined
+-- removeRedundantQualifieds Pre {opens, implicitInner, explicitModule} = undefined
 
 --------------------------------------------------------------------------------
 -- Code for generating the fully realized OpenMap

--- a/library/Translate/src/Juvix/FrontendContextualise/Contextify/ResolveOpenInfo.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/Contextify/ResolveOpenInfo.hs
@@ -10,6 +10,21 @@ import qualified Juvix.Library.HashMap as HashMap
 import qualified Juvix.Library.NameSymbol as NameSymbol
 import qualified StmContainers.Map as STM
 
+--------------------------------------------------------------------------------
+-- Types for resolving opens
+--------------------------------------------------------------------------------
+-- - before we are able to qaulify all symbols, we need the context at
+--   a fully realized state.
+-- - This hosts
+--   1. the module
+--   2. the inner modules (which thus have implciit opens of all
+--      opens)
+--   3. All opens
+-- - Since we desugar all modules to records, we can't have opens over
+--   them, hence no need to store it separately
+-- - Any resolution will thus happen at the explicit module itself, as
+--   trying to do so in the inner modules would lead to a path error
+
 data PreQualified
   = Pre
       { opens :: [NameSymbol.T],
@@ -106,6 +121,7 @@ populateOpen ctx (explicitModule, opens) = do
               pure $ Just (impExp, sym)
           updateSymbol key (Just (_, sym')) =
             throw @"left" (ModuleConflict key [sym, sym'])
+          --
           checkInScopeUp sym val =
             case NameSpace.lookupInternal sym inScopeNames of
               Just __ -> pure Nothing
@@ -171,7 +187,6 @@ grabQualifiedMap ctx name =
 -- | @removeRedundantQualifieds@ takes a qualified and removes any
 -- redundant imports it may contain
 removeRedundantQualifieds Pre {opens, implicitInner, explicitModule} = undefined
-
 
 --------------------------------------------------------------------------------
 -- Code for generating the fully realized OpenMap

--- a/library/Translate/src/Juvix/FrontendContextualise/Contextify/ResolveOpenInfo.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/Contextify/ResolveOpenInfo.hs
@@ -5,8 +5,10 @@ import qualified Juvix.Core.Common.Context as Context
 import qualified Juvix.Core.Common.Open as Open
 import Juvix.Library
 import qualified Juvix.Library.HashMap as HashMap
+import qualified Data.HashSet as Set
 import qualified Juvix.Library.NameSymbol as NameSymbol
 import qualified StmContainers.Map as STM
+import qualified Juvix.Core.Common.NameSpace as NameSpace
 
 data PreQualified
   = Pre
@@ -19,7 +21,25 @@ data PreQualified
 data Error
   = UnknownModule NameSymbol.T
   | CantResolveModules [NameSymbol.T]
+  | OpenNonModule (Set.HashSet Context.NameSymbol)
+  | AmbiguousSymbol Symbol
+  | IllegalModuleSwitch Context.NameSymbol
   deriving (Show, Eq)
+
+data Resolve a b c
+  = Res
+      { resolved :: [(Context.From (Context.Definition a b c), NameSymbol.T)],
+        notResolved :: [NameSymbol.T]
+      }
+  deriving (Show)
+
+type PureSymbolMap = HashMap.Map Symbol Context.SymbolInfo
+type OpenMap = HashMap.T NameSymbol.T [Open NameSymbol.T]
+
+data Open a
+  = Implicit a
+  | Explicit a
+  deriving (Show, Eq, Ord)
 
 type RunM =
   ExceptT Error IO
@@ -36,48 +56,241 @@ run ::
   [PreQualified] ->
   IO (Either Error (Context.T term ty sumRep))
 run ctx qualifieds = do
-  resolved <- resolve ctx qualifieds
+  resolved <-
+    runM $ do
+      resolved <- resolve ctx qualifieds
+      populateOpens resolved ctx
+      createReverseOpenMap resolved ctx
   case resolved of
     Right reverse -> pure (Right ctx {Context.reverseLookup = reverse})
     Left error -> pure (Left error)
 
-resolve :: Context.T a b c -> [PreQualified] -> IO (Either Error Context.ReverseLookup)
-resolve ctx = runM . foldM (resolveSingle ctx) mempty
+--------------------------------------------------------------------------------
+-- Functionality operating over a fully resolved open Map
+--------------------------------------------------------------------------------
+
+createReverseOpenMap ::
+  (HasThrow "left" Error m, MonadIO m) => OpenMap -> Context.T a b c -> m Context.ReverseLookup
+createReverseOpenMap open ctx = do
+  foldM (resolveReverseOpen ctx) mempty (HashMap.toList open)
+
+populateOpens ::
+  (HasThrow "left" Error m, MonadIO m) => OpenMap -> Context.T a b c -> m ()
+populateOpens opens ctx = do
+  traverse_ (populateOpen ctx) (HashMap.toList opens)
+
+populateOpen ::
+   (HasThrow "left" Error m, MonadIO m) =>
+   Context.T a b c ->
+   (NameSymbol.T, [Open NameSymbol.T]) ->
+   m ()
+populateOpen ctx (explicitModule, opens) = do
+  symbolMap <- grabQualifiedMap ctx explicitModule
+  liftIO (hashMaptoSTMMap pureHashMap symbolMap)
+  where
+    f a map =
+      let (sym, impExp) =
+            case a of
+              Implicit x -> (x, Open.Implicit)
+              Explicit x -> (x, Open.Explicit)
+      in undefined
+    pureHashMap = foldr f mempty opens
+
+resolveReverseOpen ::
+   (HasThrow "left" Error m, MonadIO m) =>
+   Context.T a b c ->
+   Context.ReverseLookup ->
+   (NameSymbol.T, [Open NameSymbol.T]) ->
+   m Context.ReverseLookup
+resolveReverseOpen ctx reverseLookup (explicitModule, opens) = do
+   symbolMap <- grabQualifiedMap ctx explicitModule
+   let updateRevLook impExplict existing =
+         let whousesInfo =
+               Context.Who {impExplict, modName = explicitModule, symbolMap}
+         in case existing of
+              Nothing -> Just [whousesInfo]
+              Just es -> Just (whousesInfo : es)
+       alterUpdate (Implicit a) = HashMap.alter (updateRevLook Open.Implicit) a
+       alterUpdate (Explicit a) = HashMap.alter (updateRevLook Open.Explicit) a
+   pure (foldr alterUpdate reverseLookup opens)
+
+
+hashMaptoSTMMap ::
+  (Eq k, Hashable k) => HashMap.HashMap k v -> STM.Map k v -> IO ()
+hashMaptoSTMMap pureMap stmMap =
+  traverse_
+    (\(k,v) -> atomically $ STM.insert v k stmMap)
+    (HashMap.toList pureMap)
+
+
+--------------------------------------------------------------------------------
+-- Code for generating the fully realized OpenMap
+--------------------------------------------------------------------------------
+
+-- We do some repeat work here
+
+-- This section is messy and was copied from a previous iteration The
+-- algorithm below tries to resolve all modules fully and gives an
+-- explicitly qualified mapping.
+
+-- TODO ∷ how do implicit opens and explicit interact, who wins?  Since
+-- this generates a list we can probably just filter and ste out the
+-- differences
+
+-- | @resolve@ takes a context and a list of open modules and the modules
+-- they are open in (the module itself, and sub modules, which the opens are
+-- implicit), and fully resolves the opens to their full name.
+-- for example @open Prelude@ in the module Londo translates to
+-- @resolve ctx PreQualified {opens = [Prelude]}@
+-- == @Right (fromList [(TopLevel :| [Londo],[Explicit (TopLevel :| [Prelude])])])@
+resolve ::
+  (HasThrow "left" Error m, MonadIO m) => Context.T a b c -> [PreQualified] -> m OpenMap
+resolve ctx = foldM (resolveSingle ctx) mempty
 
 resolveSingle ::
   (HasThrow "left" Error m, MonadIO m) =>
   Context.T a b c ->
-  Context.ReverseLookup ->
+  OpenMap ->
   PreQualified ->
-  m Context.ReverseLookup
-resolveSingle ctx reverseLookup Pre {opens, implicitInner, explicitModule} =
-  case nameSpace of
-    Nothing ->
-      throw @"left" (UnknownModule explicitModule)
-    Just ctx -> do
-      let symbolMap =
-            ctx ^. Context._currentNameSpace . Context.qualifiedMap
-          updateRevLook impExplict existing =
-            let whousesInfo =
-                  Context.Who {impExplict, modName = explicitModule, symbolMap}
-             in case existing of
-                  Nothing -> Just [whousesInfo]
-                  Just es -> Just (whousesInfo : es)
-          alterUpdate = HashMap.alter . updateRevLook
-          newResolve =
-            foldr (alterUpdate Open.Explicit) reverseLookup opens
-              |> \lookup ->
-                foldr (alterUpdate Open.Implicit) lookup implicitInner
-      -- TODO ∷ put logic that mutates the local opens here
-      undefined
-      pure newResolve
-  where
-    nameSpace = Context.inNameSpace explicitModule ctx
+  m OpenMap
+resolveSingle ctx openMap Pre {opens, implicitInner, explicitModule} = do
+  switched <- liftIO $ Context.switchNameSpace explicitModule ctx
+  case switched of
+    Left (Context.VariableShared err) ->
+      throw @"left" (IllegalModuleSwitch err)
+    Right ctx -> do
+      resolved <- liftEither (pathsCanBeResolved ctx opens)
+      qualifiedNames <- liftEither (resolveLoop ctx mempty resolved)
+      openMap
+        |> HashMap.insert explicitModule (fmap Explicit qualifiedNames)
+        |> ( \map ->
+               foldr
+                 (\mod -> HashMap.insert mod (fmap Implicit qualifiedNames))
+                 map
+                 implicitInner
+           )
+        |> pure
+
 
 grabQualifiedMap ::
   HasThrow "left" Error m => Context.T a b c -> NameSymbol.T -> m Context.SymbolMap
 grabQualifiedMap ctx name =
   case Context.extractValue <$> Context.lookup name ctx of
-    Just (Context.Record Context.Rec {recordQualifiedMap}) ->
-      pure recordQualifiedMap
-    _ -> throw @"left" (UnknownModule (Context.qualifyName name ctx))
+    Just (Context.Record rec') ->
+      pure (rec' ^. Context.qualifiedMap)
+    _ ->
+      throw @"left" (UnknownModule (Context.qualifyName name ctx))
+
+-- | @removeRedundantQualifieds@ takes a qualified and removes any
+-- redundant imports it may contain
+removeRedundantQualifieds Pre {opens, implicitInner, explicitModule} = undefined
+
+-- this goes off after the checks have passed regarding if the paths
+-- are even possible to resolve
+resolveLoop ::
+  Context.T a b c ->
+  HashMap.Map Symbol NameSymbol.T ->
+  Resolve a b c ->
+  Either Error [NameSymbol.T]
+resolveLoop ctx map Res {resolved, notResolved = cantResolveNow} = do
+  map <- foldM addToModMap map fullyQualifyRes
+  --
+  let newResolve = resolveWhatWeCan ctx (qualifyCant map <$> cantResolveNow)
+  --
+  if  | null cantResolveNow ->
+        Right qualifedAns
+      | length (notResolved newResolve) == length cantResolveNow ->
+        Left (CantResolveModules cantResolveNow)
+      | otherwise ->
+        (qualifedAns <>) <$> resolveLoop ctx map newResolve
+  where
+    fullyQualifyRes =
+      Context.resolveName ctx <$> resolved
+    qualifedAns =
+      fmap snd fullyQualifyRes
+    addToModMap map (def, sym) =
+      case def of
+        Context.Record Context.Rec {recordContents} ->
+          let NameSpace.List {publicL} = NameSpace.toList recordContents
+           in foldlM
+                ( \map x ->
+                    case map HashMap.!? x of
+                      -- this means we already have opened this in another
+                      -- module
+                      Just _ -> Left (AmbiguousSymbol x)
+                      -- if it's already in scope from below or above us
+                      -- don't add to the remapping
+                      Nothing ->
+                        case Context.lookup (pure x) ctx of
+                          Just _ -> Right map
+                          Nothing -> Right (HashMap.insert x sym map)
+                )
+                map
+                (fmap fst publicL)
+        -- should be updated when we can open expressions
+        _ ->
+          Left (UnknownModule sym)
+    qualifyCant newMap term =
+      case newMap HashMap.!? NameSymbol.hd term of
+        Nothing ->
+          term
+        Just x ->
+          x <> term
+
+-- Since Locals and top level beats opens, we can determine from the
+-- start that any module which tries to open a nested path fails,
+-- yet any previous part succeeds, that an illegal open is happening,
+-- and we can error out immediately
+
+liftEither :: HasThrow "left" e m => Either e a -> m a
+liftEither (Left le) = throw @"left" le
+liftEither (Right x) = pure x
+
+-- | @pathsCanBeResolved@ takes a context and a list of opens,
+-- we then try to resolve if the opens are legal, if so we return
+-- a list of ones that can be determined now, and a list to be resolved
+pathsCanBeResolved ::
+  Context.T a b c -> [NameSymbol.T] -> Either Error (Resolve a b c)
+pathsCanBeResolved ctx opens
+  | fmap firstName (notResolved resFull) == notResolved resFirst =
+    Right resFull
+  | otherwise =
+    Left (OpenNonModule diff)
+  where
+    resFull = resolveWhatWeCan ctx opens
+    resFirst = resolveWhatWeCan ctx (firstName <$> opens)
+    setRes l = Set.fromList (notResolved l)
+    -- O(n log₁₆(n))
+    diff =
+      mappend
+        (Set.difference (setRes resFull) (setRes resFirst))
+        (Set.difference (setRes resFirst) (setRes resFull))
+
+resolveWhatWeCan :: Context.T a b c -> [NameSymbol.T] -> Resolve a b c
+resolveWhatWeCan ctx opens = Res {resolved, notResolved}
+  where
+    dupLook =
+      fmap (\openMod -> (Context.lookup openMod ctx, openMod))
+    (resolved, notResolved) =
+      splitMaybes (dupLook opens)
+
+----------------------------------------
+-- Helpers for resolve
+----------------------------------------
+
+splitMaybes :: [(Maybe a, b)] -> ([(a, b)], [b])
+splitMaybes = foldr f ([], [])
+  where
+    f (Just a, b) = first ((a, b) :)
+    f (Nothing, b) = second (b :)
+
+-- TODO ∷ add test for firstName
+firstName :: NameSymbol.T -> NameSymbol.T
+firstName (x :| y : _)
+  | Context.topLevelName == x =
+    x :| [y]
+  | otherwise =
+    NameSymbol.fromSymbol x
+firstName xs =
+  NameSymbol.hd xs
+    |> NameSymbol.fromSymbol

--- a/library/Translate/src/Juvix/FrontendContextualise/Contextify/ResolveOpenInfo.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/Contextify/ResolveOpenInfo.hs
@@ -119,6 +119,9 @@ populateOpen ctx (explicitModule, opens) = do
           updateSymbol _ (Just (Open.Implicit, _))
             | Open.Implicit /= impExp =
               pure $ Just (impExp, sym)
+          updateSymbol _ same@(Just (Open.Explicit, _))
+            | Open.Implicit == impExp =
+              pure same
           updateSymbol key (Just (_, sym')) =
             throw @"left" (ModuleConflict key [sym, sym'])
           --

--- a/library/Translate/src/Juvix/FrontendContextualise/Environment.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/Environment.hs
@@ -1,7 +1,9 @@
 module Juvix.FrontendContextualise.Environment where
 
+import Control.Lens hiding ((|>))
 import qualified Juvix.Core.Common.Context as Context
 import qualified Juvix.Core.Common.NameSpace as NameSpace
+import qualified Juvix.Core.Common.Open as Open
 import Juvix.Library
 import qualified Juvix.Library.NameSymbol as NameSymbol
 
@@ -92,3 +94,77 @@ addUnknownGlobal (Context.Current sym) = addUnknown sym
 addUnknownGlobal (Context.Outside sym) =
   Juvix.Library.modify @"new"
     (Context.addGlobal (pure sym) (Context.Unknown Nothing))
+
+------------------------------------------------------------
+-- double module setup and dealings
+------------------------------------------------------------
+
+setupNewModule ::
+  Context.T term1 ty1 sumRep1 -> IO (Context.T term2 ty2 sumRep2)
+setupNewModule t = do
+  empt <- Context.empty (Context.currentName t)
+  empt
+    |> set
+      (Context._currentNameSpace . Context.qualifiedMap)
+      (t ^. Context._currentNameSpace . Context.qualifiedMap)
+    |> set Context._reverseLookup (t ^. Context._reverseLookup)
+    |> pure
+
+-- | @switchContext@ takes two modules representing the same context
+-- and attempts to switch the namespace while keeping the pointers
+-- consistent
+switchContext ::
+  NameSymbol.T ->
+  Context.T term ty sumRep ->
+  Context.T term2 ty2 sumRep2 ->
+  IO
+    ( Either
+        Context.PathError
+        (Context.T term ty sumRep, Context.T term2 ty2 sumRep2)
+    )
+switchContext sym ctx1 ctx2 = do
+  let switched1 = Context.inNameSpace sym ctx1
+      switched2 = Context.inNameSpace sym ctx2
+  case (switched1, switched2) of
+    (Just c1, Just c2) -> pure $ Right (c1, c2)
+    (Nothing, Nothing) -> pure $ Left (Context.VariableShared sym)
+    (Just c1, Nothing) -> setupFill sym c1 ctx2
+    (Nothing, Just c2) -> setupFill sym c2 ctx1 >>| fmap swap
+
+-- | @oneFilled@ takes a namesymbol and filled out parts of a currently
+-- added module and creates a new context with that module filled out
+oneFilled ::
+  NameSymbol.T ->
+  ([Open.TName NameSymbol.T], Context.SymbolMap) ->
+  Context.T term ty sumRep ->
+  IO (Either Context.PathError (Context.T term ty sumRep))
+oneFilled sym (openList, qualifiedMap) ctx =
+  Context.addPathWithValue
+    sym
+    (Context.Record (Context.Rec NameSpace.empty Nothing openList qualifiedMap))
+    ctx
+
+-- | @setupFilled@ takes two contexts, one that successfully switched
+-- modules and another that hasn't and inserts the needed information
+-- to keep the pointers consistent
+setupFill ::
+  NameSymbol.T ->
+  Context.T term1 ty1 sumRep1 ->
+  Context.T term2 ty2 sumRep2 ->
+  IO
+    ( Either
+        Context.PathError
+        (Context.T term1 ty1 sumRep1, Context.T term2 ty2 sumRep2)
+    )
+setupFill sym cWorks cDoesntWork = do
+  let args =
+        ( cWorks ^. Context._currentNameSpace . Context.openList,
+          cWorks ^. Context._currentNameSpace . Context.qualifiedMap
+        )
+  newInserted <- oneFilled sym args cDoesntWork
+  case newInserted of
+    Right cInserted ->
+      -- This will always be a just!
+      let Just cNowWorks = Context.inNameSpace sym cInserted
+       in pure $ Right (cWorks, cNowWorks)
+    Left err -> pure $ Left err

--- a/library/Translate/src/Juvix/FrontendContextualise/InfixPrecedence/Environment.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/InfixPrecedence/Environment.hs
@@ -202,6 +202,6 @@ queryInfo s = Juvix.Library.ask @"dispatch" >>= queryInfo' s
 
 runEnv :: Context a -> Old Context.T -> IO (Either Error a, Environment)
 runEnv (Ctx c) old = do
-  ctx <- Context.empty (Context.currentName old)
+  ctx <- setupNewModule old
   Env old ctx EnvDispatch
     |> runStateT (runExceptT c)

--- a/library/Translate/src/Juvix/FrontendContextualise/InfixPrecedence/Transform.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/InfixPrecedence/Transform.hs
@@ -580,13 +580,7 @@ updateSym :: Env.WorkingMaps env m => Context.NameSymbol -> m ()
 updateSym sym = do
   old <- get @"old"
   new <- get @"new"
-  switched <- liftIO $ Context.switchNameSpace sym old
+  switched <- liftIO $ Env.switchContext sym old new
   case switched of
-    -- bad Error for now
-    Left ____ -> throw @"error" (Env.PathError sym)
-    Right map -> put @"old" map
-  -- have to do this again sadly
-  switched2 <- liftIO $ Context.switchNameSpace sym new
-  case switched2 of
-    Left ____ -> throw @"error" (Env.PathError sym)
-    Right map -> put @"new" map
+    Right (o, n) -> put @"old" o >> put @"new" n
+    Left _ -> throw @"error" (Env.UnknownSymbol sym)

--- a/library/Translate/src/Juvix/FrontendContextualise/ModuleOpen/Environment.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/ModuleOpen/Environment.hs
@@ -391,6 +391,7 @@ removeModMap s = Juvix.Library.modify @"modMap" (Map.delete s)
 -- any place where this is inconsistent will break resolution
 
 -- TODO ∷ check if the module opens are populated
+
 -- | @populateModMap@ populates the modMap with all the global opens
 -- in the module
 populateModMap ::

--- a/library/Translate/src/Juvix/FrontendContextualise/ModuleOpen/Environment.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/ModuleOpen/Environment.hs
@@ -390,6 +390,7 @@ removeModMap s = Juvix.Library.modify @"modMap" (Map.delete s)
 -- also terms must be in either the old map or the new map
 -- any place where this is inconsistent will break resolution
 
+-- TODO ∷ check if the module opens are populated
 -- | @populateModMap@ populates the modMap with all the global opens
 -- in the module
 populateModMap ::

--- a/library/Translate/src/Juvix/FrontendContextualise/ModuleOpen/Environment.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/ModuleOpen/Environment.hs
@@ -6,6 +6,7 @@
 module Juvix.FrontendContextualise.ModuleOpen.Environment
   ( module Juvix.FrontendContextualise.ModuleOpen.Environment,
     module Juvix.FrontendContextualise.Environment,
+    Open (..),
   )
 where
 
@@ -15,6 +16,7 @@ import Data.Kind (Constraint)
 import qualified Juvix.Core.Common.Context as Context
 import qualified Juvix.Core.Common.NameSpace as NameSpace
 import qualified Juvix.FrontendContextualise.Contextify.ResolveOpenInfo as ResolveOpen
+import Juvix.FrontendContextualise.Contextify.ResolveOpenInfo (Open (..))
 import Juvix.FrontendContextualise.Environment
 import qualified Juvix.FrontendContextualise.ModuleOpen.Types as New
 import qualified Juvix.FrontendDesugar.RemoveDo.Types as Old
@@ -116,11 +118,6 @@ data Error
   | ConflictingSymbols Context.NameSymbol
   | CantResolveModules [NameSymbol.T]
   deriving (Show, Eq)
-
-data Open a
-  = Implicit a
-  | Explicit a
-  deriving (Show, Eq, Ord)
 
 type ContextAlias =
   ExceptT Error (StateT Environment IO)

--- a/library/Translate/src/Juvix/FrontendContextualise/ModuleOpen/Environment.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/ModuleOpen/Environment.hs
@@ -13,13 +13,13 @@ import qualified Data.HashSet as Set
 import Data.Kind (Constraint)
 import qualified Juvix.Core.Common.Context as Context
 import qualified Juvix.Core.Common.NameSpace as NameSpace
+import qualified Juvix.FrontendContextualise.Contextify.ResolveOpenInfo as ResolveOpen
 import Juvix.FrontendContextualise.Environment
 import qualified Juvix.FrontendContextualise.ModuleOpen.Types as New
 import qualified Juvix.FrontendDesugar.RemoveDo.Types as Old
 import Juvix.Library
 import qualified Juvix.Library.HashMap as Map
 import qualified Juvix.Library.NameSymbol as NameSymbol
-import qualified Juvix.FrontendContextualise.Contextify.ResolveOpenInfo as ResolveOpen
 
 --------------------------------------------------------------------------------
 -- Type Aliases and effect setup
@@ -353,11 +353,12 @@ runEnv (Ctx c) old pres = do
   resolved <- ResolveOpen.run old pres
   empt <- Context.empty (Context.currentName old)
   undefined
-  -- case resolved of
-  --   Right opens ->
-  --     Env old empt mempty opens EnvDispatch
-  --       |> runStateT (runExceptT c)
-  --   Left err -> pure (Left err, undefined)
+
+-- case resolved of
+--   Right opens ->
+--     Env old empt mempty opens EnvDispatch
+--       |> runStateT (runExceptT c)
+--   Left err -> pure (Left err, undefined)
 
 -- for this function just the first part of the symbol is enough
 qualifyName ::

--- a/library/Translate/src/Juvix/FrontendContextualise/ModuleOpen/Transform.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/ModuleOpen/Transform.hs
@@ -557,7 +557,4 @@ transformNameSet p (Old.NonPunned s e) =
 --------------------------------------------------------------------------------
 
 updateSym :: Env.Expression tag m => Context.NameSymbol -> m ()
-updateSym sym = do
-  Env.switchNameSpace sym
--- we now also have to populate the modmap
--- Env.populateModMap
+updateSym = Env.switchNameSpace

--- a/library/Translate/test/Contextualise/Module/Open.hs
+++ b/library/Translate/test/Contextualise/Module/Open.hs
@@ -20,8 +20,7 @@ openTests :: T.TestTree
 openTests =
   T.testGroup
     "Open Resolve Tests:"
-    [ -- openPreludeActsProperly,
-      topLevelToImportDoesntMatter,
+    [ topLevelToImportDoesntMatter,
       ambiSymbolInOpen,
       notAmbiIfLocalF,
       notAmbiIfTopLevel
@@ -195,19 +194,3 @@ notAmbiIfTopLevel =
       )
         |> T.testCase
           "opening same symbol with it being in the module is not ambi"
--- onlyOpenProperSymbols :: T.TestTree
--- onlyOpenProperSymbols =
---   ( do
---       max <- Context.empty (pure "Max")
---       prelude <- preludeAdded
---       Right opens <- resolvePreludeAdded
---       (_, Env.Env {modMap}) <-
---         Env.bareRun
---           Env.populateModMap
---           max
---           prelude
---           opens
---       modMap T.@=? mempty
---   )
---     |> T.testCase
---       "explicit symbols don't get added to the symbol mapping"

--- a/library/Translate/test/Contextualise/Module/Open.hs
+++ b/library/Translate/test/Contextualise/Module/Open.hs
@@ -4,6 +4,7 @@ module Contextualise.Module.Open where
 
 import qualified Juvix.Core.Common.Context as Context
 import qualified Juvix.Core.Common.NameSpace as NameSpace
+import qualified Juvix.FrontendContextualise.Contextify.ResolveOpenInfo as Resolve
 import qualified Juvix.FrontendContextualise.ModuleOpen.Environment as Env
 import qualified Juvix.FrontendContextualise.ModuleOpen.Types as Types
 import Juvix.Library
@@ -19,12 +20,12 @@ openTests :: T.TestTree
 openTests =
   T.testGroup
     "Open Resolve Tests:"
-    [ openPreludeActsProperly,
+    [ -- openPreludeActsProperly,
       topLevelToImportDoesntMatter,
       ambiSymbolInOpen,
       notAmbiIfLocalF,
-      notAmbiIfTopLevel,
-      onlyOpenProperSymbols
+      notAmbiIfTopLevel
+      -- onlyOpenProperSymbols
     ]
 
 --------------------------------------------------------------------------------
@@ -61,16 +62,17 @@ ourModule = do
     Right ctx -> pure ctx
     Left ____ -> pure prelude
 
-resolveOurModule :: IO (Either Env.Error Env.OpenMap)
+resolveOurModule :: IO (Either Resolve.Error Resolve.OpenMap)
 resolveOurModule = do
   mod <- ourModule
-  Env.resolve
+  Resolve.resolve
     mod
-    [ Env.Pre
+    [ Resolve.Pre
         [Context.topLevelName :| ["Prelude"]]
         []
         (Context.topLevelName :| ["Londo"])
     ]
+    |> Resolve.runM
 
 sameSymbolModule :: IO (Env.New Context.T)
 sameSymbolModule = do
@@ -108,11 +110,12 @@ preludeAdded = do
         Context.add (NameSpace.Pub "phantasm") (defaultDef "") switched'
   pure added''
 
-resolvePreludeAdded :: IO (Either Env.Error Env.OpenMap)
+resolvePreludeAdded :: IO (Either Resolve.Error Resolve.OpenMap)
 resolvePreludeAdded = do
   prelude <- preludeAdded
-  [Env.Pre [pure "Stirner", pure "Londo"] [] (Context.topLevelName :| ["Max"])]
-    |> Env.resolve prelude
+  [Resolve.Pre [pure "Stirner", pure "Londo"] [] (Context.topLevelName :| ["Max"])]
+    |> Resolve.resolve prelude
+    |> Resolve.runM
 
 --------------------------------------------------------------------------------
 -- Tests
@@ -124,35 +127,36 @@ topLevelToImportDoesntMatter =
       mod <- ourModule
       resolvedTopWithPrelude <- resolveOurModule
       resolved <-
-        Env.resolve
+        Resolve.resolve
           mod
-          [ Env.Pre
+          [ Resolve.Pre
               [pure "Prelude"]
               []
               (Context.topLevelName :| ["Londo"])
           ]
+          |> Resolve.runM
       resolvedTopWithPrelude T.@=? resolved
   )
     |> T.testCase
       "adding top level to module open does not matter if there is no lower module"
 
-openPreludeActsProperly :: T.TestTree
-openPreludeActsProperly =
-  T.testCase
-    "-> and : should fully qualify"
-    ( do
-        Right opens <- resolveOurModule
-        ourMod <- ourModule
-        emptyMod <- (Context.empty (pure "Londo"))
-        (_, Env.Env {modMap}) <-
-          Env.bareRun Env.populateModMap emptyMod ourMod opens
-        let openMap =
-              Map.fromList
-                [ (":", Context.topLevelName :| ["Prelude"]),
-                  ("->", Context.topLevelName :| ["Prelude"])
-                ]
-        modMap T.@=? openMap
-    )
+-- openPreludeActsProperly :: T.TestTree
+-- openPreludeActsProperly =
+--   T.testCase
+--     "-> and : should fully qualify"
+--     ( do
+--         Right opens <- resolveOurModule
+--         ourMod <- ourModule
+--         emptyMod <- (Context.empty (pure "Londo"))
+--         (_, Env.Env {modMap}) <-
+--           Env.bareRun Env.populateModMap emptyMod ourMod opens
+--         let openMap =
+--               Map.fromList
+--                 [ (":", Context.topLevelName :| ["Prelude"]),
+--                   ("->", Context.topLevelName :| ["Prelude"])
+--                 ]
+--         modMap T.@=? openMap
+--     )
 
 ambiSymbolInOpen :: T.TestTree
 ambiSymbolInOpen =
@@ -161,9 +165,10 @@ ambiSymbolInOpen =
       Right switched <-
         Context.switchNameSpace (Context.topLevelName :| ["Max"]) sameSymbolModule
       resovled <-
-        [Env.Pre [pure "Stirner", pure "Londo"] [] (Context.topLevelName :| ["Max"])]
-          |> Env.resolve switched
-      resovled T.@=? Left (Env.AmbiguousSymbol "phantasm")
+        [Resolve.Pre [pure "Stirner", pure "Londo"] [] (Context.topLevelName :| ["Max"])]
+          |> Resolve.resolve switched
+          |> Resolve.runM
+      resovled T.@=? Left (Resolve.AmbiguousSymbol "phantasm")
   )
     |> T.testCase
       "opening same symbol with it not being in the module def should be ambi"
@@ -184,8 +189,9 @@ notAmbiIfLocalF =
                 )
               ]
       resovled <-
-        [Env.Pre [pure "Stirner", pure "Londo"] [] (Context.topLevelName :| ["Max"])]
-          |> Env.resolve added
+        [Resolve.Pre [pure "Stirner", pure "Londo"] [] (Context.topLevelName :| ["Max"])]
+          |> Resolve.resolve added
+          |> Resolve.runM
       resovled T.@=? Right opens
   )
     |> T.testCase
@@ -207,20 +213,19 @@ notAmbiIfTopLevel =
       )
         |> T.testCase
           "opening same symbol with it being in the module is not ambi"
-
-onlyOpenProperSymbols :: T.TestTree
-onlyOpenProperSymbols =
-  ( do
-      max <- Context.empty (pure "Max")
-      prelude <- preludeAdded
-      Right opens <- resolvePreludeAdded
-      (_, Env.Env {modMap}) <-
-        Env.bareRun
-          Env.populateModMap
-          max
-          prelude
-          opens
-      modMap T.@=? mempty
-  )
-    |> T.testCase
-      "explicit symbols don't get added to the symbol mapping"
+-- onlyOpenProperSymbols :: T.TestTree
+-- onlyOpenProperSymbols =
+--   ( do
+--       max <- Context.empty (pure "Max")
+--       prelude <- preludeAdded
+--       Right opens <- resolvePreludeAdded
+--       (_, Env.Env {modMap}) <-
+--         Env.bareRun
+--           Env.populateModMap
+--           max
+--           prelude
+--           opens
+--       modMap T.@=? mempty
+--   )
+--     |> T.testCase
+--       "explicit symbols don't get added to the symbol mapping"

--- a/library/Translate/test/Contextualise/Module/Open.hs
+++ b/library/Translate/test/Contextualise/Module/Open.hs
@@ -24,7 +24,6 @@ openTests =
       ambiSymbolInOpen,
       notAmbiIfLocalF,
       notAmbiIfTopLevel
-      -- onlyOpenProperSymbols
     ]
 
 --------------------------------------------------------------------------------

--- a/library/Translate/test/Contextualise/Module/Open.hs
+++ b/library/Translate/test/Contextualise/Module/Open.hs
@@ -140,24 +140,6 @@ topLevelToImportDoesntMatter =
     |> T.testCase
       "adding top level to module open does not matter if there is no lower module"
 
--- openPreludeActsProperly :: T.TestTree
--- openPreludeActsProperly =
---   T.testCase
---     "-> and : should fully qualify"
---     ( do
---         Right opens <- resolveOurModule
---         ourMod <- ourModule
---         emptyMod <- (Context.empty (pure "Londo"))
---         (_, Env.Env {modMap}) <-
---           Env.bareRun Env.populateModMap emptyMod ourMod opens
---         let openMap =
---               Map.fromList
---                 [ (":", Context.topLevelName :| ["Prelude"]),
---                   ("->", Context.topLevelName :| ["Prelude"])
---                 ]
---         modMap T.@=? openMap
---     )
-
 ambiSymbolInOpen :: T.TestTree
 ambiSymbolInOpen =
   ( do

--- a/library/Translate/test/Contextualise/Module/Resolve.hs
+++ b/library/Translate/test/Contextualise/Module/Resolve.hs
@@ -2,24 +2,50 @@
 
 module Contextualise.Module.Resolve where
 
+import qualified Contextualise.Module.Open as Open
+import Control.Lens hiding ((|>))
 import qualified Juvix.Core.Common.Context as Context
+import qualified Juvix.Core.Common.Context as Ctx
 import qualified Juvix.Core.Common.NameSpace as NameSpace
 import qualified Juvix.FrontendContextualise.Contextify.ResolveOpenInfo as Resolve
 import qualified Juvix.FrontendContextualise.ModuleOpen.Environment as Env
 import qualified Juvix.FrontendContextualise.ModuleOpen.Types as Types
 import Juvix.Library
 import qualified Juvix.Library.HashMap as Map
+import qualified ListT
+import qualified StmContainers.Map as STM
 import qualified Test.Tasty as T
 import qualified Test.Tasty.HUnit as T
-import qualified Contextualise.Module.Open as Open
 
+top :: T.TestTree
+top =
+  T.testGroup
+    "context resolve tests:"
+    [ preludeProperlyOpens
+    ]
 
+firstResolve :: IO (Either Resolve.Error (Env.New Context.T))
 firstResolve = do
   our <- Open.ourModule
   Resolve.run
     our
-    [Resolve.Pre
-       [Context.topLevelName :| ["Prelude"]]
-       []
-       (Context.topLevelName :| ["Londo"])
+    [ Resolve.Pre
+        [Context.topLevelName :| ["Prelude"]]
+        []
+        (Context.topLevelName :| ["Londo"])
     ]
+
+preludeProperlyOpens :: T.TestTree
+preludeProperlyOpens =
+  T.testCase
+    "-> and : should be in the qualifying map"
+    ( do
+        Right resolved <- firstResolve
+        let stmMap = resolved ^. Context._currentNameSpace . Context.qualifiedMap
+            answer =
+              [ (":", Ctx.SymInfo {used = Ctx.NotUsed, mod = "TopLevel" :| ["Prelude"]}),
+                ("->", Ctx.SymInfo {used = Ctx.NotUsed, mod = "TopLevel" :| ["Prelude"]})
+              ]
+        reality <- atomically (ListT.toList $ STM.listT stmMap)
+        reality T.@=? answer
+    )

--- a/library/Translate/test/Contextualise/Module/Resolve.hs
+++ b/library/Translate/test/Contextualise/Module/Resolve.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE LiberalTypeSynonyms #-}
+
+module Contextualise.Module.Resolve where
+
+import qualified Juvix.Core.Common.Context as Context
+import qualified Juvix.Core.Common.NameSpace as NameSpace
+import qualified Juvix.FrontendContextualise.Contextify.ResolveOpenInfo as Resolve
+import qualified Juvix.FrontendContextualise.ModuleOpen.Environment as Env
+import qualified Juvix.FrontendContextualise.ModuleOpen.Types as Types
+import Juvix.Library
+import qualified Juvix.Library.HashMap as Map
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
+import qualified Contextualise.Module.Open as Open
+
+
+firstResolve = do
+  our <- Open.ourModule
+  Resolve.run
+    our
+    [Resolve.Pre
+       [Context.topLevelName :| ["Prelude"]]
+       []
+       (Context.topLevelName :| ["Londo"])
+    ]

--- a/library/Translate/test/Main.hs
+++ b/library/Translate/test/Main.hs
@@ -3,6 +3,7 @@ module Main where
 import qualified Contextualise.Contextify as Contextify
 import Contextualise.Infix.ShuntYard (allInfixTests)
 import Contextualise.Module.Open (openTests)
+import qualified Contextualise.Module.Resolve as Resolve
 import Desugar (allDesugar)
 import Golden (contractFiles)
 import Juvix.Library (IO)
@@ -27,7 +28,8 @@ allCheckedTests =
     [ frontEndTests,
       allInfixTests,
       openTests,
-      Contextify.top
+      Contextify.top,
+      Resolve.top
     ]
 
 main :: IO ()

--- a/test/Pipeline.hs
+++ b/test/Pipeline.hs
@@ -67,6 +67,7 @@ exec (EnvE env) param globals = do
 
 type Globals = IR.Globals PrimTy PrimValIR
 
+
 type AnnTuple = (P.RawMichelsonTerm, Usage.T, P.RawMichelsonTerm)
 
 shouldCompileTo ::

--- a/test/Pipeline.hs
+++ b/test/Pipeline.hs
@@ -67,7 +67,6 @@ exec (EnvE env) param globals = do
 
 type Globals = IR.Globals PrimTy PrimValIR
 
-
 type AnnTuple = (P.RawMichelsonTerm, Usage.T, P.RawMichelsonTerm)
 
 shouldCompileTo ::


### PR DESCRIPTION
This PR does a few things and is a followup on #593.

1. utilize the context's new features. We need to make a seperate open pass instead of doing it adhoc on the spot 
2. Retro fit the data structures in the pas to commit this style
3. Consider any differences between single definition down and the entire pipeline down