### PR TITLE
Renamed `make build-opt` -> `make build-prod` in README (#675)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For Windows users: to be able to use the command *make*, please visit [this link
 For full optimisations (but slower compile times):
 
 ```bash
-make build-opt
+make build-prod
 ```
 
 ## Usage


### PR DESCRIPTION
`build-opt` was still used in the README as the way to build a production optimised
Juvix compiler. This has been matched to the Makefile's `build-prod`.