### PR TITLE
Split --ghc-options to avoid problems with stack (#679)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build-watch:
 	stack build --fast --file-watch
 
 build-prod: clean
-	stack build --jobs $(THREADS) --ghc-options "-O3 -fllvm" --flag juvix:incomplete-error
+	stack build --jobs $(THREADS) --ghc-options="-O3" --ghc-options="-fllvm" --flag juvix:incomplete-error
 
 build-format:
 	stack install ormolu


### PR DESCRIPTION
When I try to build the optimised compiler, I am greeted with an error from stack:

```
stack build --jobs 4 --ghc-options "-O3 -fllvm" --flag juvix:incomplete-error
Invalid option `-fllvm'

Usage: stack build [TARGET] [--dry-run] [--pedantic] [--fast]
....
```

-fllvm is treated as an option to stack, and not as part of the --ghc-options flag. This is a known issue commercialhaskell/stack#3315, that apparently was fixed. I am running a more recent version of stack (2.5.1), but it still comes up as a problem.

A solution to this is by using multiple --ghc-options flags:

```
stack build --jobs 4 --ghc-options "-O3" --ghc-options "-fllvm" --flag juvix:incomplete-error
```