### PR TITLE
Binder aware traversal function for context passes

### DIFF
--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1831,6 +1831,8 @@ done with no extra information needed. Thus we export the following passes
   + [[Frontend/Sexp]]
   + [[Frontend/Types/Base]]
   + [[FrontendContextualise]]
+  + [[ResolveOpenInfo]]
+  + [[Contextify/Types]]
   + [[FrontendContextualise/Environment]]
   + [[Library]]
   + [[HashMap]]

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1839,6 +1839,7 @@ done with no extra information needed. Thus we export the following passes
   + [[FrontendContextualise/Environment]]
   + [[Library]]
   + [[HashMap]]
+  + [[NameSymbol]]
   + [[Library/Sexp]]
 *** Contextualise
 **** Contextify

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1422,6 +1422,22 @@ Can be added to via core translation
 ** Setup <<Translate/Setup>>
 ** src
 *** Juvix
+**** FrontendDesugar
+- Order of Passes
+  1. =RemoveModule=
+  2. =RemoveGuard=
+  3. =RemoveCond=
+  4. =CombineMultiple=
+  5. =RemoveSignature=
+  6. =RemovePunned=
+  7. =RemoveDo=
+- _Relies on_
+  + [[Juvix/Conversion/ML]]
+  + [[Juvix/Desugar]]
+  + [[Desugar/Types]]
+  + [[Frontend/Sexp]]
+  + [[Frontend/Types]]
+  + [[Library]]
 **** Conversion
 ***** ML <<Juvix/Conversion/ML>>
 This module is responsible for converting back S-expressions back
@@ -1799,22 +1815,6 @@ done with no extra information needed. Thus we export the following passes
 - _Relies on_
   + [[Frontend/Types/Base]]
   + [[ModuleOpen/Extend]]
-  + [[Library]]
-**** FrontendDesugar
-- Order of Passes
-  1. =RemoveModule=
-  2. =RemoveGuard=
-  3. =RemoveCond=
-  4. =CombineMultiple=
-  5. =RemoveSignature=
-  6. =RemovePunned=
-  7. =RemoveDo=
-- _Relies on_
-  + [[Juvix/Conversion/ML]]
-  + [[Juvix/Desugar]]
-  + [[Desugar/Types]]
-  + [[Frontend/Sexp]]
-  + [[Frontend/Types]]
   + [[Library]]
 ** test
 *** Golden

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1822,6 +1822,19 @@ done with no extra information needed. Thus we export the following passes
 *** Main <<Translate/test/Main>>
 - _Relies on_
   + [[Library]]
+*** Context
+**** Environment <<Context/Environment>>
+- _Relies on_
+  + [[Core/Common/Context]]
+  + [[Juvix/Desugar]]
+  + [[Frontend/Parser]]
+  + [[Frontend/Sexp]]
+  + [[Frontend/Types/Base]]
+  + [[FrontendContextualise]]
+  + [[FrontendContextualise/Environment]]
+  + [[Library]]
+  + [[HashMap]]
+  + [[Library/Sexp]]
 *** Contextualise
 **** Contextify
 - _Relies on_

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1594,7 +1594,9 @@ done with no extra information needed. Thus we export the following passes
   + [[NameSpace]]
   + [[Common/Open]]
   + [[Library]]
+  + [[HashMap]]
   + [[NameSymbol]]
+  + [[Library/Sexp]]
 ***** Contextify
 ****** ResolveOpenInfo
 - This module is responsible for adding the reverse open

--- a/library/StandardLibrary/src/Juvix/Library/Sexp.hs
+++ b/library/StandardLibrary/src/Juvix/Library/Sexp.hs
@@ -40,6 +40,11 @@ import Prelude (error)
 --    forms can cause binders. This is useful when we care about what
 --    is in scope for doing certain changes.
 --
+-- 3. In the case where both predicates match, then we will run the
+--    binder and then the actual transformation, this is to ensure the
+--    lexical semantics are respected, and then we can cleanup after
+--    this.
+--
 -- For arguments, this function takes a Sexp, along with 2 sets of
 -- pred function pairs. The function for the binding we take a
 -- continuation, as it's not easy to automate the recursive calls in
@@ -54,17 +59,25 @@ foldSearchPred ::
 foldSearchPred t p1@(predChange, f) p2@(predBind, g) =
   case t of
     Cons a@(Atom atom@(A name _)) xs
-      | predChange name -> do
-        newCons <- f atom xs
-        case newCons of
-          Cons _ _ ->
-            Cons (car newCons) <$> foldSearchPred (cdr newCons) p1 p2
-          _ ->
-            pure newCons
-      | predBind name -> do
+      -- this case is a bit special as we wish to remove the form but
+      -- it's a binder! So we must run it then run the transform on it!
+      | predBind name && predChange name -> do
+        bindedTerm <- bindCase
+        changeCase (cdr bindedTerm)
+      | predChange name -> changeCase xs
+      | predBind name -> bindCase
+      where
+        changeCase xs = do
+          newCons <- f atom xs
+          case newCons of
+            Cons _ _ ->
+              Cons (car newCons) <$> foldSearchPred (cdr newCons) p1 p2
+            _ ->
+              pure newCons
         -- G takes the computation, as its changes are scoped over the
         -- calls.
-        Cons a <$> g atom xs (\xs -> foldSearchPred xs p1 p2)
+        bindCase =
+          Cons a <$> g atom xs (\xs -> foldSearchPred xs p1 p2)
     Cons cs xs ->
       Cons <$> foldSearchPred cs p1 p2 <*> foldSearchPred xs p1 p2
     Nil -> pure Nil

--- a/library/StandardLibrary/src/Juvix/Library/Sexp.hs
+++ b/library/StandardLibrary/src/Juvix/Library/Sexp.hs
@@ -45,6 +45,9 @@ import Prelude (error)
 --    lexical semantics are respected, and then we can cleanup after
 --    this.
 --
+-- 4. If the @predChange@ function accepts ":atom", then the function
+--    will also be ran on the atom
+--
 -- For arguments, this function takes a Sexp, along with 2 sets of
 -- pred function pairs. The function for the binding we take a
 -- continuation, as it's not easy to automate the recursive calls in
@@ -81,7 +84,9 @@ foldSearchPred t p1@(predChange, f) p2@(predBind, g) =
     Cons cs xs ->
       Cons <$> foldSearchPred cs p1 p2 <*> foldSearchPred xs p1 p2
     Nil -> pure Nil
-    Atom a -> pure $ Atom a
+    Atom a
+      | predChange ":atom" -> f a t
+      | otherwise -> pure $ Atom a
 
 foldPred :: T -> (NameSymbol.T -> Bool) -> (Atom -> T -> T) -> T
 foldPred t pred f =

--- a/library/StandardLibrary/src/Juvix/Library/Sexp.hs
+++ b/library/StandardLibrary/src/Juvix/Library/Sexp.hs
@@ -20,6 +20,7 @@ module Juvix.Library.Sexp
     assoc,
     cadr,
     foldSearchPred,
+    unGroupBy2,
   )
 where
 
@@ -181,3 +182,10 @@ groupBy2 :: T -> T
 groupBy2 (a1 :> a2 :> rest) =
   list [a1, a2] :> groupBy2 rest
 groupBy2 _ = Nil
+
+unGroupBy2 :: T -> T
+unGroupBy2 (List [a1, a2] :> rest) =
+  a1 :> a2 :> unGroupBy2 rest
+unGroupBy2 (a :> rest) =
+  a :> unGroupBy2 rest
+unGroupBy2 a = a

--- a/library/Translate/src/Juvix/FrontendContextualise/Contextify/Sexp.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/Contextify/Sexp.hs
@@ -216,9 +216,18 @@ decideRecordOrDef xs@(Sexp.List [Sexp.List [Sexp.Nil, body]]) recordName currMod
         f x _ = pure x
     _ -> def
   where
-    def = pure (Context.Def (Context.D Nothing ty xs pres), [])
+    def =
+      pure
+        ( Context.Def
+            (Context.D Nothing ty (Sexp.atom ":lambda-case" Sexp.:> xs) pres),
+          []
+        )
 decideRecordOrDef xs _ _ pres ty =
-  pure (Context.Def (Context.D Nothing ty xs pres), [])
+  pure
+    ( Context.Def
+        (Context.D Nothing ty (Sexp.atom ":lambda-case" Sexp.:> xs) pres),
+      []
+    )
 
 collectConstructors :: Sexp.T -> [Symbol]
 collectConstructors dat

--- a/library/Translate/src/Juvix/FrontendContextualise/Environment.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/Environment.hs
@@ -197,7 +197,7 @@ newtype Closure'
   = Closure (Map.T Symbol Information)
   deriving (Show, Eq)
 
-data ErrorS = CantResolve [Sexp.T]
+newtype ErrorS = CantResolve [Sexp.T] deriving (Show, Eq)
 
 type SexpContext = Context.T Sexp.T Sexp.T Sexp.T
 

--- a/library/Translate/src/Juvix/FrontendContextualise/Environment.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/Environment.hs
@@ -251,7 +251,10 @@ passContext ctx trigger Pass {sumF, termF, tyF} =
   Context.mapWithContext
     ctx
     Context.CtxForm
-      { sumF = pass sumF,
+      { -- Need to do this consing of type to figure out we are in a type
+        -- we then need to remove it, as it shouldn't be there
+        sumF = \form ->
+          fmap Sexp.cdr . pass sumF (Sexp.Cons (Sexp.atom "type") form),
         termF = pass termF,
         tyF = pass tyF
       }

--- a/library/Translate/src/Juvix/FrontendContextualise/Environment.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/Environment.hs
@@ -1,6 +1,7 @@
 module Juvix.FrontendContextualise.Environment where
 
 import Control.Lens hiding ((|>))
+import qualified Data.HashSet as Set
 import qualified Juvix.Core.Common.Context as Context
 import qualified Juvix.Core.Common.NameSpace as NameSpace
 import qualified Juvix.Core.Common.Open as Open
@@ -216,6 +217,9 @@ addToClosure k info (Closure m) =
 genericBind :: Symbol -> Closure' -> Closure'
 genericBind name (Closure m) =
   Closure $ Map.insert name (Info Nothing [] Nothing) m
+
+keys :: Closure' -> Set.HashSet Symbol
+keys (Closure m) = Map.keysSet m
 
 data Pass m
   = Pass

--- a/library/Translate/src/Juvix/FrontendContextualise/Environment.hs
+++ b/library/Translate/src/Juvix/FrontendContextualise/Environment.hs
@@ -222,6 +222,15 @@ data Pass m
         tyF :: Sexp.Atom -> Sexp.T -> m Sexp.T
       }
 
+passContextSingle ::
+  (HasClosure m, ErrS m) =>
+  SexpContext ->
+  (NameSymbol.T -> Bool) ->
+  (Sexp.Atom -> Sexp.T -> m Sexp.T) ->
+  m SexpContext
+passContextSingle ctx trigger f =
+  passContext ctx trigger (Pass f f f)
+
 passContext ::
   (HasClosure m, ErrS m) => SexpContext -> (NameSymbol.T -> Bool) -> Pass m -> m SexpContext
 passContext ctx trigger Pass {sumF, termF, tyF} =

--- a/library/Translate/test/Context/Environment.hs
+++ b/library/Translate/test/Context/Environment.hs
@@ -16,7 +16,7 @@ import qualified Juvix.Library.NameSymbol as NameSymbol
 import qualified Juvix.Library.Sexp as Sexp
 import qualified Test.Tasty as T
 import qualified Test.Tasty.HUnit as T
-import Prelude (error, fail)
+import Prelude (error)
 
 --------------------------------------------------------------------------------
 -- Top Level Test
@@ -79,7 +79,7 @@ passContext :: T.TestTree
 passContext =
   T.testGroup
     "testing passContext closures"
-    [letTest, typeTest, caseTest, lambdaTest]
+    [letTest, typeTest, caseTest, lambdaTest, declaimTest]
 
 ----------------------------------------
 -- Let Test
@@ -168,13 +168,30 @@ caseTest =
 lambdaTest :: T.TestTree
 lambdaTest =
   T.testGroup
-    "lambda binder"
-    [ T.testCase "lambda properly adds binders" $ do
+    "λ binder"
+    [ T.testCase "λ properly adds binders" $ do
         [lamb] <-
           capture
             "let f = \\(Cons a b) -> (print-closure 3)"
             trigger
         Env.keys lamb T.@=? Set.fromList ["a", "b"]
+    ]
+  where
+    trigger =
+      (== "print-closure")
+
+declaimTest :: T.TestTree
+declaimTest =
+  T.testGroup
+    "declaim binder"
+    [ T.testCase "declaim properly adds info" $ do
+        [lamb] <-
+          capture
+            "let f = declare infixl (+) 7 in print-closure 2"
+            trigger
+        -- we could check for info, but this is sufficient for it
+        -- properly working
+        Env.keys lamb T.@=? Set.fromList ["+"]
     ]
   where
     trigger =

--- a/library/Translate/test/Context/Environment.hs
+++ b/library/Translate/test/Context/Environment.hs
@@ -102,13 +102,27 @@ letTest =
             Map.keysSet x T.@=? firstClosure
             Map.keysSet y T.@=? secondClosure
           _ ->
-            fail "not enough captured closures"
+            fail "not enough captured closures",
+      T.testCase "let binds for its own arguments" $ do
+        Right (ctx, _) <- contextualizeFoo "let f a = let foo x y = 3 in foo"
+        let (_, Cap _ capture) =
+              emptyClosure
+                |> runCtx (Env.passContextSingle ctx (== ":atom") recordClosure)
+        case capture of
+          [a, x, y, three, foo] -> do
+            Env.keys a T.@=? Set.fromList ["a"]
+            Env.keys x T.@=? argumentBinding
+            Env.keys y T.@=? argumentBinding
+            Env.keys three T.@=? argumentBinding
+            Env.keys foo T.@=? Set.fromList ["a", "foo"]
     ]
   where
     firstClosure =
       Set.fromList ["g", "foo", "x"]
     secondClosure =
       Set.fromList ["g", "foo", "a", "y", "z"]
+    argumentBinding =
+      Set.fromList ["a", "foo", "x", "y"]
     trigger =
       (== "print-closure")
 

--- a/library/Translate/test/Context/Environment.hs
+++ b/library/Translate/test/Context/Environment.hs
@@ -1,0 +1,137 @@
+module Context.Environment (top) where
+
+import qualified Data.HashSet as Set
+import qualified Juvix.Core.Common.Context as Context
+import qualified Juvix.Desugar as Desugar
+import qualified Juvix.Frontend.Parser as Parser
+import qualified Juvix.Frontend.Sexp as SexpTrans
+import qualified Juvix.Frontend.Types.Base as Frontend
+import qualified Juvix.FrontendContextualise as Contextualize
+import qualified Juvix.FrontendContextualise.Environment as Env
+import Juvix.Library
+import qualified Juvix.Library.HashMap as Map
+import qualified Juvix.Library.Sexp as Sexp
+import qualified Test.Tasty as T
+import qualified Test.Tasty.HUnit as T
+import Prelude (error, fail)
+
+--------------------------------------------------------------------------------
+-- Top Level Test
+--------------------------------------------------------------------------------
+
+top :: T.TestTree
+top =
+  T.testGroup
+    "testing environment functions"
+    [passContext]
+
+--------------------------------------------------------------------------------
+-- Environment Runner Types
+--------------------------------------------------------------------------------
+data Capture
+  = Cap
+      { closure :: Env.Closure',
+        report :: [Env.Closure']
+      }
+  deriving (Generic, Show)
+
+type CaptureAlias =
+  ExceptT Env.ErrorS (State Capture)
+
+newtype Context a = Ctx {run :: CaptureAlias a}
+  deriving (Functor, Applicative, Monad)
+  deriving
+    ( HasReader "closure" Env.Closure',
+      HasSource "closure" Env.Closure'
+    )
+    via ReaderField "closure" CaptureAlias
+  deriving
+    ( HasWriter "report" [Env.Closure'],
+      HasSink "report" [Env.Closure']
+    )
+    via WriterField "report" CaptureAlias
+  deriving
+    (HasThrow "error" Env.ErrorS)
+    via MonadError CaptureAlias
+
+runCtx :: Context a -> Capture -> (Either Env.ErrorS a, Capture)
+runCtx (Ctx c) = runState (runExceptT c)
+
+emptyCtx :: IO (Context.T Sexp.T Sexp.T Sexp.T)
+emptyCtx = Context.empty "Foo"
+
+emptyClosure :: Capture
+emptyClosure = Cap (Env.Closure Map.empty) []
+
+recordClosure ::
+  (HasReader "closure" a m, HasWriter "report" [a] m) => p -> b -> m b
+recordClosure _atom t = do
+  c <- ask @"closure"
+  tell @"report" [c]
+  -- Just drop the given atom
+  pure t
+
+--------------------------------------------------------------------------------
+-- PassContext Tests
+--------------------------------------------------------------------------------
+
+passContext :: T.TestTree
+passContext =
+  T.testGroup
+    "testing passContext closures"
+    [letTest]
+
+----------------------------------------
+-- Let Test
+----------------------------------------
+
+letTest :: T.TestTree
+letTest =
+  T.testGroup
+    "Let's properly add to the closure"
+    [ T.testCase "let-match" $ do
+        Right (ctx, _) <-
+          contextualizeFoo
+            "let f = let g = 3 in \
+            \ let foo (Nil x)      = print-closure 0 in \
+            \ let foo (Cons a y) z = print-closure 0 in \
+            \ 3"
+        let (_, Cap _ capture) =
+              runCtx (Env.passContextSingle ctx trigger recordClosure) emptyClosure
+        case capture of
+          [Env.Closure x, Env.Closure y] -> do
+            Map.keysSet x T.@=? firstClosure
+            Map.keysSet y T.@=? secondClosure
+          _ ->
+            fail "not enough captured closures"
+    ]
+  where
+    firstClosure =
+      Set.fromList ["g", "foo", "x"]
+    secondClosure =
+      Set.fromList ["g", "foo", "a", "y", "z"]
+    trigger =
+      (== "print-closure")
+
+-- Right (ctx,_) <- contextualizeFoo "let f = 3"
+-- (_, capture) = runCtx (Env.passContextSingle ctx (== "print-closure") recordClosure) emptyClosure
+----------------------------------------------------------------------
+-- Give me sexp terms helpers
+----------------------------------------------------------------------
+
+contextualizeFoo byte =
+  Contextualize.contextifyS (("Foo", parseDesugarSexp byte) :| [])
+
+parseDesugarSexp :: ByteString -> [Sexp.T]
+parseDesugarSexp = Desugar.op . parsedSexp
+
+parsedSexp :: ByteString -> [Sexp.T]
+parsedSexp xs = ignoreHeader (Parser.parse xs) >>| SexpTrans.transTopLevel
+
+ignoreHeader :: Either a (Frontend.Header topLevel) -> [topLevel]
+ignoreHeader (Right (Frontend.NoHeader xs)) = xs
+ignoreHeader _ = error "not no header"
+
+ignoreRight :: Either a p -> p
+ignoreRight (Right x) = x
+ignoreRight (Left _) = error "not right"

--- a/library/Translate/test/Context/Environment.hs
+++ b/library/Translate/test/Context/Environment.hs
@@ -79,7 +79,7 @@ passContext :: T.TestTree
 passContext =
   T.testGroup
     "testing passContext closures"
-    [letTest, typeTest, caseTest, lambdaTest, declaimTest]
+    [letTest, typeTest, caseTest, lambdaTest, declaimTest, openTest]
 
 ----------------------------------------
 -- Let Test
@@ -192,6 +192,24 @@ declaimTest =
         -- we could check for info, but this is sufficient for it
         -- properly working
         Env.keys lamb T.@=? Set.fromList ["+"]
+    ]
+  where
+    trigger =
+      (== "print-closure")
+
+openTest :: T.TestTree
+openTest =
+  T.testGroup
+    "open Tests"
+    [ T.testCase "open properly adds symbols" $ do
+        Right (ctx, _) <-
+          Contextualize.contextifyS
+            ( ("Foo", parseDesugarSexp "let f = open A in print-closure 2")
+                :| [("A", parseDesugarSexp "let bar = 3")]
+            )
+        let (_, Cap _ [Env.Closure capture]) =
+              runCtx (Env.passContextSingle ctx trigger recordClosure) emptyClosure
+        Map.toList capture T.@=? [("bar", Env.Info Nothing [] (Just "A"))]
     ]
   where
     trigger =

--- a/library/Translate/test/Context/Environment.hs
+++ b/library/Translate/test/Context/Environment.hs
@@ -126,6 +126,14 @@ letTest =
     trigger =
       (== "print-closure")
 
+typeTest =
+  T.testGroup
+    "Types properly add all to to the closure"
+    []
+  where
+    trigger =
+      (== "print-closure")
+
 -- Right (ctx,_) <- contextualizeFoo "let f = 3"
 -- (_, capture) = runCtx (Env.passContextSingle ctx (== "print-closure") recordClosure) emptyClosure
 ----------------------------------------------------------------------

--- a/library/Translate/test/Contextualise/Contextify.hs
+++ b/library/Translate/test/Contextualise/Contextify.hs
@@ -101,7 +101,7 @@ defunTransfomrationWorks =
     Right desugared =
       extract "sig foo : int -> int let foo 1 = 1 let foo n = n * foo (pred n)"
     Right function =
-      Sexp.parse "(((1) 1) ((n) (:infix * n (foo (:paren (pred n))))))"
+      Sexp.parse "(:lambda-case ((1) 1) ((n) (:infix * n (foo (:paren (pred n))))))"
     Right sig =
       Sexp.parse "(:infix -> int int)"
 

--- a/library/Translate/test/Main.hs
+++ b/library/Translate/test/Main.hs
@@ -1,5 +1,6 @@
 module Main where
 
+import qualified Context.Environment
 import qualified Contextualise.Contextify as Contextify
 import Contextualise.Infix.ShuntYard (allInfixTests)
 import Contextualise.Module.Open (openTests)
@@ -21,7 +22,7 @@ translationPasses :: T.TestTree
 translationPasses =
   T.testGroup
     "translation passes from Frontend to Core"
-    [allDesugar, Sexp.top, ML.top]
+    [allDesugar, Sexp.top, ML.top, Context.Environment.top]
 
 allCheckedTests :: T.TestTree
 allCheckedTests =


### PR DESCRIPTION
Ts PR gives us a generic traversal function that is aware of binders and properly handles each form that might bind.

This means that any pass that cares about closures just needs to supply a proper predicate and transform function.

We also test and document this function in this PR.