### PR TITLE
replace positivity in raw datatype with number of params

### DIFF
--- a/app/Compile.hs
+++ b/app/Compile.hs
@@ -114,7 +114,7 @@ unsafeEvalGlobal ::
   IR.Global primTy primVal
 unsafeEvalGlobal globals g =
   case g of
-    RawGDatatype (RawDatatype n pos a l cons) -> undefined
+    RawGDatatype (RawDatatype n a ps l cons) -> undefined
     RawGDataCon (RawDataCon n t d) -> undefined
     RawGFunction (RawFunction n u t cs) ->
       GFunction $
@@ -127,7 +127,7 @@ convGlobal ::
   IR.RawGlobal Param.PrimTy Param.PrimValIR
 convGlobal g =
   case g of
-    RawGDatatype (RawDatatype n pos a l cons) -> undefined
+    RawGDatatype (RawDatatype n a ps l cons) -> undefined
     RawGDataCon (RawDataCon n t d) -> undefined
     RawGFunction (RawFunction n u t cs) ->
       RawGFunction (RawFunction n u (baseToReturn t) (map funClauseReturn cs))

--- a/library/Core/src/Juvix/Core/IR/Typechecker.hs
+++ b/library/Core/src/Juvix/Core/IR/Typechecker.hs
@@ -23,7 +23,7 @@ typeCheckDeclaration ::
   IR.TypeCheck ty ext primTy primVal ()
 typeCheckDeclaration [] [] =
   return undefined
-typeCheckDeclaration ((IR.RawDatatype name lpos args levels cons) : tld) _ =
+typeCheckDeclaration ((IR.RawDatatype name args params levels cons) : tld) _ =
   undefined
 -- TODO run checkDataType 0 [] [] p' dt
 -- v <- eval [] dt

--- a/library/Core/src/Juvix/Core/IR/Types/Globals.hs
+++ b/library/Core/src/Juvix/Core/IR/Types/Globals.hs
@@ -38,10 +38,10 @@ type GlobalAll (c :: * -> Constraint) extV extT primTy primVal =
 data RawDatatype' ext primTy primVal
   = RawDatatype
       { rawDataName :: GlobalName,
-        -- | the positivity of its parameters
-        rawDataPos :: [Pos],
         -- | the type constructor's arguments
         rawDataArgs :: [RawDataArg' ext primTy primVal],
+        -- | how many parameters
+        rawDataParams :: Natural,
         -- | the type constructor's target universe level
         rawDataLevel :: Natural,
         rawDataCons :: [RawDataCon' ext primTy primVal]


### PR DESCRIPTION
since the positivity of parameters will be calculated by the typechecker, it doesn't make sense in raw datatypes. but it is still necessary to know how many arguments are parameters in the first place.