### PR TITLE
Handle escape characters in string parser

### DIFF
--- a/library/Frontend/src/Juvix/Frontend/Parser.hs
+++ b/library/Frontend/src/Juvix/Frontend/Parser.hs
@@ -122,8 +122,8 @@ expressionArguments =
     <|> P.try (Types.ExpRecord <$> expRecord)
     <|> P.try (Types.Constant <$> constant)
     -- <|> try (Types.NamedTypeE <$> namedRefine)
-    <|> P.try (Types.Name <$> prefixSymbolDot)
     <|> P.try universeSymbol
+    <|> P.try (Types.Name <$> prefixSymbolDot)
     <|> P.try (Types.List <$> list)
     -- We wrap this in a paren to avoid conflict
     -- with infixity that we don't know about at this phase!

--- a/library/Frontend/src/Juvix/Frontend/Parser.hs
+++ b/library/Frontend/src/Juvix/Frontend/Parser.hs
@@ -7,17 +7,18 @@
 --
 -- - Parsers with SN at the end, eats the spaces and new lines at the
 --   end of the parse
-module Juvix.Frontend.Parser where
-
--- ( parse,
---   expressionSN,
---   removeComments,
---   topLevelSN,
---   expression,
---   matchLogic,
---   cond,
---   prefixSymbol,
--- )
+module Juvix.Frontend.Parser
+  ( parse,
+    prettyParse,
+    expressionSN,
+    removeComments,
+    topLevelSN,
+    expression,
+    matchLogic,
+    cond,
+    prefixSymbol,
+  )
+where
 
 import Control.Arrow (left)
 import qualified Control.Monad.Combinators.Expr as Expr
@@ -601,8 +602,6 @@ float = do
   void (P.char J.dot)
   _s2 <- digits
   fail "float not implemented"
-
---   pure (read (s1 <> "." <> s2))
 
 stringEscape :: Parser ByteString
 stringEscape =

--- a/library/StandardLibrary/src/Juvix/Library/Parser/Lexer.hs
+++ b/library/StandardLibrary/src/Juvix/Library/Parser/Lexer.hs
@@ -4,6 +4,7 @@ module Juvix.Library.Parser.Lexer
     skipLiner,
     parens,
     brackets,
+    between,
     curly,
     many1H,
     sepBy1H,
@@ -14,8 +15,6 @@ module Juvix.Library.Parser.Lexer
     integer,
   )
 where
-
--- space,
 
 import qualified Data.ByteString.Char8 as Char8
 import qualified Data.List.NonEmpty as NonEmpty
@@ -76,4 +75,4 @@ integer = do
   digits <- P.takeWhileP (Just "digits") isDigit
   case Char8.readInteger digits of
     Just (x, _) -> pure x
-    Nothing -> fail $ "didn't parse an int: " <> toS digits
+    Nothing -> fail $ "didn't parse an int"

--- a/library/StandardLibrary/src/Juvix/Library/Parser/Token.hs
+++ b/library/StandardLibrary/src/Juvix/Library/Parser/Token.hs
@@ -10,6 +10,7 @@ module Juvix.Library.Parser.Token
     hash,
     backSlash,
     quote,
+    doubleQuote,
     pipe,
     equals,
     at,
@@ -102,6 +103,9 @@ backSlash = charToWord8 '\\'
 
 quote :: Word8
 quote = charToWord8 '\''
+
+doubleQuote :: Word8
+doubleQuote = charToWord8 '\"'
 
 pipe :: Word8
 pipe = charToWord8 '|'


### PR DESCRIPTION
Fixes https://github.com/heliaxdev/juvix/issues/718

Not sure if we accept both single and double quotes, but from the look of the code we do, so this PR handles both cases
```
let foo = "hello"
let bar = 'world'
```

It also fixes parsing universes. E.g.
```
let fi a = f u#a
```