### PR TITLE
Switches over the Contextify Passes to use the Structure generator

### DIFF
--- a/ChangeLog.org
+++ b/ChangeLog.org
@@ -1,4 +1,7 @@
 * Changelog for Juvix
+** 0.1.0.3
+- Changes over =Juvix.Contextify.Passes= structure to use the
+  S-expression generator instead of matching on the syntax directly
 ** 0.1.0.2
 - Switches over the =stack.yaml= depdency files to a generator to
   reduce the repeat code

--- a/ChangeLog.org
+++ b/ChangeLog.org
@@ -1,5 +1,9 @@
 * Changelog for Juvix
 ** 0.1.0.3
+- Fix: A small bug where modules would drop types with an explicit
+  signature
+  + Test: Creates a test in =Test.Desugar.Sexp= under the
+    =moduleWorksAsExpected= group
 - Changes over =Juvix.Contextify.Passes= structure to use the
   S-expression generator instead of matching on the syntax directly
 ** 0.1.0.2

--- a/ChangeLog.org
+++ b/ChangeLog.org
@@ -1,11 +1,16 @@
 * Changelog for Juvix
 ** 0.1.0.3
+- Change: over =Juvix.Contextify.Passes= structure to use the
+  S-expression generator instead of matching on the syntax directly
 - Fix: A small bug where modules would drop types with an explicit
   signature
   + Test: Creates a test in =Test.Desugar.Sexp= under the
     =moduleWorksAsExpected= group
-- Changes over =Juvix.Contextify.Passes= structure to use the
-  S-expression generator instead of matching on the syntax directly
+- Change: =let-type's= internal representation to more accurately
+  reflect the structure
+
+  =(:let-type name args (sum₁ sum₂ … sumₙ) rest)= instead of
+  =(:let-type name (args sum₁ sum₂ … sumₙ) rest)=
 ** 0.1.0.2
 - Switches over the =stack.yaml= depdency files to a generator to
   reduce the repeat code

--- a/doc/Code/Library.org
+++ b/doc/Code/Library.org
@@ -1750,6 +1750,8 @@ TODO ∷ determine what has changed in the rebasing of this algo
   + [[Library]]
   + [[NameSymbol]]
   + [[Library/Sexp]]
+  + [[Structure]]
+  + [[Lens]]
 ***** InfixPrecedence
 ****** ShuntYard <<InfixPrecedence/ShuntYard>>
 - This implements the Shunt Yard algorithm for determining the

--- a/library/Translate/src/Juvix/Desugar/Passes.hs
+++ b/library/Translate/src/Juvix/Desugar/Passes.hs
@@ -367,21 +367,26 @@ moduleTransform xs = Sexp.foldPred xs (== Structure.nameDefModule) moduleToRecor
       Sexp.foldr combine (generatedRecord body) body
     moduleToRecord atom cdr
       | Just mod <- Structure.toDefModule (Sexp.Atom atom Sexp.:> cdr) =
-      Structure.Defun (mod ^. name) (mod ^. args) (ignoreCond (mod ^. body) intoRecord)
-        |> Structure.fromDefun
-        |> Sexp.addMetaToCar atom
+        Structure.Defun (mod ^. name) (mod ^. args) (ignoreCond (mod ^. body) intoRecord)
+          |> Structure.fromDefun
+          |> Sexp.addMetaToCar atom
       | otherwise = error "malformed defmodule"
 
 -- | @moduleLetTransform@ - See @moduleTransform@'s comment
 moduleLetTransform :: Sexp.T -> Sexp.T
-moduleLetTransform xs = Sexp.foldPred xs (== ":let-mod") moduleToRecord
+moduleLetTransform xs = Sexp.foldPred xs (== Structure.nameLetModule) moduleToRecord
   where
     combineIntoRecord body =
       Sexp.foldr combine (generatedRecord body) body
-    moduleToRecord atom (name Sexp.:> args Sexp.:> body Sexp.:> rest) =
-      Structure.Let name args (ignoreCond body combineIntoRecord) rest
-        |> Structure.fromLet
-        |> Sexp.addMetaToCar atom
+    moduleToRecord atom cdr
+      | Just mod <- Structure.toLetModule (Sexp.Atom atom Sexp.:> cdr) =
+        Structure.Let
+          (mod ^. name)
+          (mod ^. args)
+          (ignoreCond (mod ^. body) combineIntoRecord)
+          (mod ^. body)
+          |> Structure.fromLet
+          |> Sexp.addMetaToCar atom
     moduleToRecord _ _ = error "malformed let-mod"
 
 ----------------------------------------

--- a/library/Translate/src/Juvix/Desugar/Passes.hs
+++ b/library/Translate/src/Juvix/Desugar/Passes.hs
@@ -453,7 +453,7 @@ grabNames (form Sexp.:> name Sexp.:> _) acc
       || Sexp.isAtomNamed form ":defsig",
     Just name <- Sexp.atomFromT name =
     name : acc
-  | Sexp.isAtomNamed (Sexp.car name) "type",
+  | Sexp.isAtomNamed form "type",
     Just name <- Sexp.atomFromT (Sexp.car name) =
     name : acc
 grabNames _ acc = acc

--- a/library/Translate/src/Juvix/Desugar/Passes.hs
+++ b/library/Translate/src/Juvix/Desugar/Passes.hs
@@ -384,7 +384,7 @@ moduleLetTransform xs = Sexp.foldPred xs (== Structure.nameLetModule) moduleToRe
           (mod ^. name)
           (mod ^. args)
           (ignoreCond (mod ^. body) combineIntoRecord)
-          (mod ^. body)
+          (mod ^. rest)
           |> Structure.fromLet
           |> Sexp.addMetaToCar atom
     moduleToRecord _ _ = error "malformed let-mod"

--- a/library/Translate/src/Juvix/Sexp/Structure.hs
+++ b/library/Translate/src/Juvix/Sexp/Structure.hs
@@ -317,7 +317,6 @@ toArgBody form =
 fromArgBody :: ArgBody -> Sexp.T
 fromArgBody (ArgBody sexp1 sexp2) =
   Sexp.list [sexp1, sexp2]
-
 ----------------------------------------
 -- Type
 ----------------------------------------
@@ -333,7 +332,7 @@ toType :: Sexp.T -> Maybe Type
 toType form
   | isType form =
     case form of
-      _Type Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 ->
+      _nameType Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 ->
         Type sexp1 sexp2 sexp3 |> Just
       _ ->
         Nothing
@@ -343,7 +342,6 @@ toType form
 fromType :: Type -> Sexp.T
 fromType (Type sexp1 sexp2 sexp3) =
   Sexp.listStar [Sexp.atom nameType, sexp1, sexp2, sexp3]
-
 ----------------------------------------
 -- LetType
 ----------------------------------------
@@ -359,7 +357,7 @@ toLetType :: Sexp.T -> Maybe LetType
 toLetType form
   | isLetType form =
     case form of
-      _LetType Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> sexp4 Sexp.:> Sexp.Nil ->
+      _nameLetType Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> sexp4 Sexp.:> Sexp.Nil ->
         LetType sexp1 sexp2 sexp3 sexp4 |> Just
       _ ->
         Nothing
@@ -369,7 +367,6 @@ toLetType form
 fromLetType :: LetType -> Sexp.T
 fromLetType (LetType sexp1 sexp2 sexp3 sexp4) =
   Sexp.list [Sexp.atom nameLetType, sexp1, sexp2, sexp3, sexp4]
-
 ----------------------------------------
 -- Defun
 ----------------------------------------
@@ -385,7 +382,7 @@ toDefun :: Sexp.T -> Maybe Defun
 toDefun form
   | isDefun form =
     case form of
-      _Defun Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> Sexp.Nil ->
+      _nameDefun Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> Sexp.Nil ->
         Defun sexp1 sexp2 sexp3 |> Just
       _ ->
         Nothing
@@ -395,7 +392,6 @@ toDefun form
 fromDefun :: Defun -> Sexp.T
 fromDefun (Defun sexp1 sexp2 sexp3) =
   Sexp.list [Sexp.atom nameDefun, sexp1, sexp2, sexp3]
-
 ----------------------------------------
 -- DefunMatch
 ----------------------------------------
@@ -411,7 +407,7 @@ toDefunMatch :: Sexp.T -> Maybe DefunMatch
 toDefunMatch form
   | isDefunMatch form =
     case form of
-      _DefunMatch Sexp.:> sexp1 Sexp.:> argBody2
+      _nameDefunMatch Sexp.:> sexp1 Sexp.:> argBody2
         | Just argBody2 <- toArgBody `fromStarList` argBody2 ->
           DefunMatch sexp1 argBody2 |> Just
       _ ->
@@ -422,7 +418,6 @@ toDefunMatch form
 fromDefunMatch :: DefunMatch -> Sexp.T
 fromDefunMatch (DefunMatch sexp1 argBody2) =
   Sexp.listStar [Sexp.atom nameDefunMatch, sexp1, fromArgBody `toStarList` argBody2]
-
 ----------------------------------------
 -- DefunSigMatch
 ----------------------------------------
@@ -438,7 +433,7 @@ toDefunSigMatch :: Sexp.T -> Maybe DefunSigMatch
 toDefunSigMatch form
   | isDefunSigMatch form =
     case form of
-      _DefunSigMatch Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> argBody3
+      _nameDefunSigMatch Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> argBody3
         | Just argBody3 <- toArgBody `fromStarList` argBody3 ->
           DefunSigMatch sexp1 sexp2 argBody3 |> Just
       _ ->
@@ -449,7 +444,6 @@ toDefunSigMatch form
 fromDefunSigMatch :: DefunSigMatch -> Sexp.T
 fromDefunSigMatch (DefunSigMatch sexp1 sexp2 argBody3) =
   Sexp.listStar [Sexp.atom nameDefunSigMatch, sexp1, sexp2, fromArgBody `toStarList` argBody3]
-
 ----------------------------------------
 -- Signature
 ----------------------------------------
@@ -465,7 +459,7 @@ toSignature :: Sexp.T -> Maybe Signature
 toSignature form
   | isSignature form =
     case form of
-      _Signature Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> Sexp.Nil ->
+      _nameSignature Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> Sexp.Nil ->
         Signature sexp1 sexp2 |> Just
       _ ->
         Nothing
@@ -475,7 +469,6 @@ toSignature form
 fromSignature :: Signature -> Sexp.T
 fromSignature (Signature sexp1 sexp2) =
   Sexp.list [Sexp.atom nameSignature, sexp1, sexp2]
-
 ----------------------------------------
 -- LetSignature
 ----------------------------------------
@@ -491,7 +484,7 @@ toLetSignature :: Sexp.T -> Maybe LetSignature
 toLetSignature form
   | isLetSignature form =
     case form of
-      _LetSignature Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> Sexp.Nil ->
+      _nameLetSignature Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> Sexp.Nil ->
         LetSignature sexp1 sexp2 sexp3 |> Just
       _ ->
         Nothing
@@ -501,7 +494,6 @@ toLetSignature form
 fromLetSignature :: LetSignature -> Sexp.T
 fromLetSignature (LetSignature sexp1 sexp2 sexp3) =
   Sexp.list [Sexp.atom nameLetSignature, sexp1, sexp2, sexp3]
-
 ----------------------------------------
 -- Let
 ----------------------------------------
@@ -517,7 +509,7 @@ toLet :: Sexp.T -> Maybe Let
 toLet form
   | isLet form =
     case form of
-      _Let Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> sexp4 Sexp.:> Sexp.Nil ->
+      _nameLet Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> sexp4 Sexp.:> Sexp.Nil ->
         Let sexp1 sexp2 sexp3 sexp4 |> Just
       _ ->
         Nothing
@@ -527,7 +519,6 @@ toLet form
 fromLet :: Let -> Sexp.T
 fromLet (Let sexp1 sexp2 sexp3 sexp4) =
   Sexp.list [Sexp.atom nameLet, sexp1, sexp2, sexp3, sexp4]
-
 ----------------------------------------
 -- LetMatch
 ----------------------------------------
@@ -543,7 +534,7 @@ toLetMatch :: Sexp.T -> Maybe LetMatch
 toLetMatch form
   | isLetMatch form =
     case form of
-      _LetMatch Sexp.:> sexp1 Sexp.:> argBodys2 Sexp.:> sexp3 Sexp.:> Sexp.Nil
+      _nameLetMatch Sexp.:> sexp1 Sexp.:> argBodys2 Sexp.:> sexp3 Sexp.:> Sexp.Nil
         | Just argBodys2 <- toArgBodys argBodys2 ->
           LetMatch sexp1 argBodys2 sexp3 |> Just
       _ ->
@@ -554,7 +545,6 @@ toLetMatch form
 fromLetMatch :: LetMatch -> Sexp.T
 fromLetMatch (LetMatch sexp1 argBodys2 sexp3) =
   Sexp.list [Sexp.atom nameLetMatch, sexp1, fromArgBodys argBodys2, sexp3]
-
 ----------------------------------------
 -- PredAns
 ----------------------------------------
@@ -570,7 +560,6 @@ toPredAns form =
 fromPredAns :: PredAns -> Sexp.T
 fromPredAns (PredAns sexp1 sexp2) =
   Sexp.list [sexp1, sexp2]
-
 ----------------------------------------
 -- Cond
 ----------------------------------------
@@ -586,7 +575,7 @@ toCond :: Sexp.T -> Maybe Cond
 toCond form
   | isCond form =
     case form of
-      _Cond Sexp.:> predAns1
+      _nameCond Sexp.:> predAns1
         | Just predAns1 <- toPredAns `fromStarList` predAns1 ->
           Cond predAns1 |> Just
       _ ->
@@ -597,7 +586,6 @@ toCond form
 fromCond :: Cond -> Sexp.T
 fromCond (Cond predAns1) =
   Sexp.listStar [Sexp.atom nameCond, fromPredAns `toStarList` predAns1]
-
 ----------------------------------------
 -- If
 ----------------------------------------
@@ -613,7 +601,7 @@ toIf :: Sexp.T -> Maybe If
 toIf form
   | isIf form =
     case form of
-      _If Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> Sexp.Nil ->
+      _nameIf Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> Sexp.Nil ->
         If sexp1 sexp2 sexp3 |> Just
       _ ->
         Nothing
@@ -623,7 +611,6 @@ toIf form
 fromIf :: If -> Sexp.T
 fromIf (If sexp1 sexp2 sexp3) =
   Sexp.list [Sexp.atom nameIf, sexp1, sexp2, sexp3]
-
 ----------------------------------------
 -- IfNoElse
 ----------------------------------------
@@ -639,7 +626,7 @@ toIfNoElse :: Sexp.T -> Maybe IfNoElse
 toIfNoElse form
   | isIfNoElse form =
     case form of
-      _IfNoElse Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> Sexp.Nil ->
+      _nameIfNoElse Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> Sexp.Nil ->
         IfNoElse sexp1 sexp2 |> Just
       _ ->
         Nothing
@@ -649,7 +636,6 @@ toIfNoElse form
 fromIfNoElse :: IfNoElse -> Sexp.T
 fromIfNoElse (IfNoElse sexp1 sexp2) =
   Sexp.list [Sexp.atom nameIfNoElse, sexp1, sexp2]
-
 ----------------------------------------
 -- DeconBody
 ----------------------------------------
@@ -665,7 +651,6 @@ toDeconBody form =
 fromDeconBody :: DeconBody -> Sexp.T
 fromDeconBody (DeconBody sexp1 sexp2) =
   Sexp.list [sexp1, sexp2]
-
 ----------------------------------------
 -- Case
 ----------------------------------------
@@ -681,7 +666,7 @@ toCase :: Sexp.T -> Maybe Case
 toCase form
   | isCase form =
     case form of
-      _Case Sexp.:> sexp1 Sexp.:> deconBody2
+      _nameCase Sexp.:> sexp1 Sexp.:> deconBody2
         | Just deconBody2 <- toDeconBody `fromStarList` deconBody2 ->
           Case sexp1 deconBody2 |> Just
       _ ->
@@ -692,7 +677,6 @@ toCase form
 fromCase :: Case -> Sexp.T
 fromCase (Case sexp1 deconBody2) =
   Sexp.listStar [Sexp.atom nameCase, sexp1, fromDeconBody `toStarList` deconBody2]
-
 ----------------------------------------
 -- Do
 ----------------------------------------
@@ -708,7 +692,7 @@ toDo :: Sexp.T -> Maybe Do
 toDo form
   | isDo form =
     case form of
-      _Do Sexp.:> sexp1 ->
+      _nameDo Sexp.:> sexp1 ->
         Do sexp1 |> Just
       _ ->
         Nothing
@@ -718,7 +702,6 @@ toDo form
 fromDo :: Do -> Sexp.T
 fromDo (Do sexp1) =
   Sexp.listStar [Sexp.atom nameDo, sexp1]
-
 ----------------------------------------
 -- Arrow
 ----------------------------------------
@@ -734,7 +717,7 @@ toArrow :: Sexp.T -> Maybe Arrow
 toArrow form
   | isArrow form =
     case form of
-      _Arrow Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> Sexp.Nil ->
+      _nameArrow Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> Sexp.Nil ->
         Arrow sexp1 sexp2 |> Just
       _ ->
         Nothing
@@ -744,7 +727,6 @@ toArrow form
 fromArrow :: Arrow -> Sexp.T
 fromArrow (Arrow sexp1 sexp2) =
   Sexp.list [Sexp.atom nameArrow, sexp1, sexp2]
-
 ----------------------------------------
 -- Lambda
 ----------------------------------------
@@ -760,7 +742,7 @@ toLambda :: Sexp.T -> Maybe Lambda
 toLambda form
   | isLambda form =
     case form of
-      _Lambda Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> Sexp.Nil ->
+      _nameLambda Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> Sexp.Nil ->
         Lambda sexp1 sexp2 |> Just
       _ ->
         Nothing
@@ -770,7 +752,6 @@ toLambda form
 fromLambda :: Lambda -> Sexp.T
 fromLambda (Lambda sexp1 sexp2) =
   Sexp.list [Sexp.atom nameLambda, sexp1, sexp2]
-
 ----------------------------------------
 -- Punned
 ----------------------------------------
@@ -786,7 +767,6 @@ toPunned form =
 fromPunned :: Punned -> Sexp.T
 fromPunned (Punned sexp1) =
   Sexp.list [sexp1]
-
 ----------------------------------------
 -- NotPunned
 ----------------------------------------
@@ -802,7 +782,6 @@ toNotPunned form =
 fromNotPunned :: NotPunned -> Sexp.T
 fromNotPunned (NotPunned sexp1 sexp2) =
   Sexp.list [sexp1, sexp2]
-
 ----------------------------------------
 -- Record
 ----------------------------------------
@@ -818,7 +797,7 @@ toRecord :: Sexp.T -> Maybe Record
 toRecord form
   | isRecord form =
     case form of
-      _Record Sexp.:> nameBind1
+      _nameRecord Sexp.:> nameBind1
         | Just nameBind1 <- toNameBind `fromStarList` nameBind1 ->
           Record nameBind1 |> Just
       _ ->
@@ -829,7 +808,6 @@ toRecord form
 fromRecord :: Record -> Sexp.T
 fromRecord (Record nameBind1) =
   Sexp.listStar [Sexp.atom nameRecord, fromNameBind `toStarList` nameBind1]
-
 ----------------------------------------
 -- RecordNoPunned
 ----------------------------------------
@@ -845,7 +823,7 @@ toRecordNoPunned :: Sexp.T -> Maybe RecordNoPunned
 toRecordNoPunned form
   | isRecordNoPunned form =
     case form of
-      _RecordNoPunned Sexp.:> notPunnedGroup1
+      _nameRecordNoPunned Sexp.:> notPunnedGroup1
         | Just notPunnedGroup1 <- toNotPunnedGroup notPunnedGroup1 ->
           RecordNoPunned notPunnedGroup1 |> Just
       _ ->
@@ -856,7 +834,6 @@ toRecordNoPunned form
 fromRecordNoPunned :: RecordNoPunned -> Sexp.T
 fromRecordNoPunned (RecordNoPunned notPunnedGroup1) =
   Sexp.listStar [Sexp.atom nameRecordNoPunned, fromNotPunnedGroup notPunnedGroup1]
-
 ----------------------------------------
 -- Infix
 ----------------------------------------
@@ -872,7 +849,7 @@ toInfix :: Sexp.T -> Maybe Infix
 toInfix form
   | isInfix form =
     case form of
-      _Infix Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> Sexp.Nil ->
+      _nameInfix Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> Sexp.Nil ->
         Infix sexp1 sexp2 sexp3 |> Just
       _ ->
         Nothing
@@ -882,7 +859,6 @@ toInfix form
 fromInfix :: Infix -> Sexp.T
 fromInfix (Infix sexp1 sexp2 sexp3) =
   Sexp.list [Sexp.atom nameInfix, sexp1, sexp2, sexp3]
-
 ----------------------------------------
 -- OpenIn
 ----------------------------------------
@@ -898,7 +874,7 @@ toOpenIn :: Sexp.T -> Maybe OpenIn
 toOpenIn form
   | isOpenIn form =
     case form of
-      _OpenIn Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> Sexp.Nil ->
+      _nameOpenIn Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> Sexp.Nil ->
         OpenIn sexp1 sexp2 |> Just
       _ ->
         Nothing
@@ -908,7 +884,6 @@ toOpenIn form
 fromOpenIn :: OpenIn -> Sexp.T
 fromOpenIn (OpenIn sexp1 sexp2) =
   Sexp.list [Sexp.atom nameOpenIn, sexp1, sexp2]
-
 ----------------------------------------
 -- Open
 ----------------------------------------
@@ -924,7 +899,7 @@ toOpen :: Sexp.T -> Maybe Open
 toOpen form
   | isOpen form =
     case form of
-      _Open Sexp.:> sexp1 Sexp.:> Sexp.Nil ->
+      _nameOpen Sexp.:> sexp1 Sexp.:> Sexp.Nil ->
         Open sexp1 |> Just
       _ ->
         Nothing
@@ -934,7 +909,6 @@ toOpen form
 fromOpen :: Open -> Sexp.T
 fromOpen (Open sexp1) =
   Sexp.list [Sexp.atom nameOpen, sexp1]
-
 ----------------------------------------
 -- Declare
 ----------------------------------------
@@ -950,7 +924,7 @@ toDeclare :: Sexp.T -> Maybe Declare
 toDeclare form
   | isDeclare form =
     case form of
-      _Declare Sexp.:> sexp1 Sexp.:> Sexp.Nil ->
+      _nameDeclare Sexp.:> sexp1 Sexp.:> Sexp.Nil ->
         Declare sexp1 |> Just
       _ ->
         Nothing
@@ -960,7 +934,6 @@ toDeclare form
 fromDeclare :: Declare -> Sexp.T
 fromDeclare (Declare sexp1) =
   Sexp.list [Sexp.atom nameDeclare, sexp1]
-
 ----------------------------------------
 -- Declaim
 ----------------------------------------
@@ -976,7 +949,7 @@ toDeclaim :: Sexp.T -> Maybe Declaim
 toDeclaim form
   | isDeclaim form =
     case form of
-      _Declaim Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> Sexp.Nil ->
+      _nameDeclaim Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> Sexp.Nil ->
         Declaim sexp1 sexp2 |> Just
       _ ->
         Nothing
@@ -986,7 +959,6 @@ toDeclaim form
 fromDeclaim :: Declaim -> Sexp.T
 fromDeclaim (Declaim sexp1 sexp2) =
   Sexp.list [Sexp.atom nameDeclaim, sexp1, sexp2]
-
 ----------------------------------------
 -- DefModule
 ----------------------------------------
@@ -1002,7 +974,7 @@ toDefModule :: Sexp.T -> Maybe DefModule
 toDefModule form
   | isDefModule form =
     case form of
-      _DefModule Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 ->
+      _nameDefModule Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 ->
         DefModule sexp1 sexp2 sexp3 |> Just
       _ ->
         Nothing
@@ -1012,7 +984,6 @@ toDefModule form
 fromDefModule :: DefModule -> Sexp.T
 fromDefModule (DefModule sexp1 sexp2 sexp3) =
   Sexp.listStar [Sexp.atom nameDefModule, sexp1, sexp2, sexp3]
-
 ----------------------------------------
 -- LetModule
 ----------------------------------------
@@ -1028,7 +999,7 @@ toLetModule :: Sexp.T -> Maybe LetModule
 toLetModule form
   | isLetModule form =
     case form of
-      _LetModule Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> sexp4 Sexp.:> Sexp.Nil ->
+      _nameLetModule Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> sexp4 Sexp.:> Sexp.Nil ->
         LetModule sexp1 sexp2 sexp3 sexp4 |> Just
       _ ->
         Nothing

--- a/library/Translate/src/Juvix/Sexp/Structure.hs
+++ b/library/Translate/src/Juvix/Sexp/Structure.hs
@@ -181,9 +181,25 @@ data Infix = Infix
   }
   deriving (Show)
 
+newtype Open = Open
+  { openName :: Sexp.T
+  }
+  deriving (Show)
+
 data OpenIn = OpenIn
   { openInName :: Sexp.T,
     openInBody :: Sexp.T
+  }
+  deriving (Show)
+
+newtype Declare = Declare
+  { declareClaim :: Sexp.T
+  }
+  deriving (Show)
+
+data Declaim = Declaim
+  { declaimClaim :: Sexp.T,
+    declaimBody :: Sexp.T
   }
   deriving (Show)
 
@@ -768,3 +784,81 @@ toOpenIn form
 fromOpenIn :: OpenIn -> Sexp.T
 fromOpenIn (OpenIn sexp1 sexp2) =
   Sexp.list [Sexp.atom nameOpenIn, sexp1, sexp2]
+
+----------------------------------------
+-- Open
+----------------------------------------
+
+nameOpen :: NameSymbol.T
+nameOpen = "open"
+
+isOpen :: Sexp.T -> Bool
+isOpen (Sexp.Cons form _) = Sexp.isAtomNamed form nameOpen
+isOpen _ = False
+
+toOpen :: Sexp.T -> Maybe Open
+toOpen form
+  | isOpen form =
+    case form of
+      _Open Sexp.:> sexp1 Sexp.:> Sexp.Nil ->
+        Open sexp1 |> Just
+      _ ->
+        Nothing
+  | otherwise =
+    Nothing
+
+fromOpen :: Open -> Sexp.T
+fromOpen (Open sexp1) =
+  Sexp.list [Sexp.atom nameOpen, sexp1]
+
+----------------------------------------
+-- Declare
+----------------------------------------
+
+nameDeclare :: NameSymbol.T
+nameDeclare = "declare"
+
+isDeclare :: Sexp.T -> Bool
+isDeclare (Sexp.Cons form _) = Sexp.isAtomNamed form nameDeclare
+isDeclare _ = False
+
+toDeclare :: Sexp.T -> Maybe Declare
+toDeclare form
+  | isDeclare form =
+    case form of
+      _Declare Sexp.:> sexp1 Sexp.:> Sexp.Nil ->
+        Declare sexp1 |> Just
+      _ ->
+        Nothing
+  | otherwise =
+    Nothing
+
+fromDeclare :: Declare -> Sexp.T
+fromDeclare (Declare sexp1) =
+  Sexp.list [Sexp.atom nameDeclare, sexp1]
+
+----------------------------------------
+-- Declaim
+----------------------------------------
+
+nameDeclaim :: NameSymbol.T
+nameDeclaim = ":declaim"
+
+isDeclaim :: Sexp.T -> Bool
+isDeclaim (Sexp.Cons form _) = Sexp.isAtomNamed form nameDeclaim
+isDeclaim _ = False
+
+toDeclaim :: Sexp.T -> Maybe Declaim
+toDeclaim form
+  | isDeclaim form =
+    case form of
+      _Declaim Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> Sexp.Nil ->
+        Declaim sexp1 sexp2 |> Just
+      _ ->
+        Nothing
+  | otherwise =
+    Nothing
+
+fromDeclaim :: Declaim -> Sexp.T
+fromDeclaim (Declaim sexp1 sexp2) =
+  Sexp.list [Sexp.atom nameDeclaim, sexp1, sexp2]

--- a/library/Translate/src/Juvix/Sexp/Structure.hs
+++ b/library/Translate/src/Juvix/Sexp/Structure.hs
@@ -1012,3 +1012,29 @@ toDefModule form
 fromDefModule :: DefModule -> Sexp.T
 fromDefModule (DefModule sexp1 sexp2 sexp3) =
   Sexp.listStar [Sexp.atom nameDefModule, sexp1, sexp2, sexp3]
+
+----------------------------------------
+-- LetModule
+----------------------------------------
+
+nameLetModule :: NameSymbol.T
+nameLetModule = ":let-mod"
+
+isLetModule :: Sexp.T -> Bool
+isLetModule (Sexp.Cons form _) = Sexp.isAtomNamed form nameLetModule
+isLetModule _ = False
+
+toLetModule :: Sexp.T -> Maybe LetModule
+toLetModule form
+  | isLetModule form =
+    case form of
+      _LetModule Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> sexp4 Sexp.:> Sexp.Nil ->
+        LetModule sexp1 sexp2 sexp3 sexp4 |> Just
+      _ ->
+        Nothing
+  | otherwise =
+    Nothing
+
+fromLetModule :: LetModule -> Sexp.T
+fromLetModule (LetModule sexp1 sexp2 sexp3 sexp4) =
+  Sexp.list [Sexp.atom nameLetModule, sexp1, sexp2, sexp3, sexp4]

--- a/library/Translate/src/Juvix/Sexp/Structure.hs
+++ b/library/Translate/src/Juvix/Sexp/Structure.hs
@@ -332,7 +332,7 @@ fromType (Type sexp1 sexp2 sexp3) =
 ----------------------------------------
 
 nameLetType :: NameSymbol.T
-nameLetType = "let-type"
+nameLetType = ":let-type"
 
 isLetType :: Sexp.T -> Bool
 isLetType (Sexp.Cons form _) = Sexp.isAtomNamed form nameLetType

--- a/library/Translate/src/Juvix/Sexp/Structure.hs
+++ b/library/Translate/src/Juvix/Sexp/Structure.hs
@@ -173,6 +173,20 @@ newtype RecordNoPunned = RecordNoPunned
   }
   deriving (Show)
 
+-- | @Infix@ represents an infix function
+data Infix = Infix
+  { infixOp :: Sexp.T,
+    infixLeft :: Sexp.T,
+    infixRight :: Sexp.T
+  }
+  deriving (Show)
+
+data OpenIn = OpenIn
+  { openInName :: Sexp.T,
+    openInBody :: Sexp.T
+  }
+  deriving (Show)
+
 --------------------------------------------------------------------------------
 -- Converter functions
 -- The format for these are
@@ -702,3 +716,55 @@ toRecordNoPunned form
 fromRecordNoPunned :: RecordNoPunned -> Sexp.T
 fromRecordNoPunned (RecordNoPunned notPunnedGroup1) =
   Sexp.listStar [Sexp.atom nameRecordNoPunned, fromNotPunnedGroup notPunnedGroup1]
+
+----------------------------------------
+-- Infix
+----------------------------------------
+
+nameInfix :: NameSymbol.T
+nameInfix = ":infix"
+
+isInfix :: Sexp.T -> Bool
+isInfix (Sexp.Cons form _) = Sexp.isAtomNamed form nameInfix
+isInfix _ = False
+
+toInfix :: Sexp.T -> Maybe Infix
+toInfix form
+  | isInfix form =
+    case form of
+      _Infix Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 Sexp.:> Sexp.Nil ->
+        Infix sexp1 sexp2 sexp3 |> Just
+      _ ->
+        Nothing
+  | otherwise =
+    Nothing
+
+fromInfix :: Infix -> Sexp.T
+fromInfix (Infix sexp1 sexp2 sexp3) =
+  Sexp.list [Sexp.atom nameInfix, sexp1, sexp2, sexp3]
+
+----------------------------------------
+-- OpenIn
+----------------------------------------
+
+nameOpenIn :: NameSymbol.T
+nameOpenIn = ":open-in"
+
+isOpenIn :: Sexp.T -> Bool
+isOpenIn (Sexp.Cons form _) = Sexp.isAtomNamed form nameOpenIn
+isOpenIn _ = False
+
+toOpenIn :: Sexp.T -> Maybe OpenIn
+toOpenIn form
+  | isOpenIn form =
+    case form of
+      _OpenIn Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> Sexp.Nil ->
+        OpenIn sexp1 sexp2 |> Just
+      _ ->
+        Nothing
+  | otherwise =
+    Nothing
+
+fromOpenIn :: OpenIn -> Sexp.T
+fromOpenIn (OpenIn sexp1 sexp2) =
+  Sexp.list [Sexp.atom nameOpenIn, sexp1, sexp2]

--- a/library/Translate/src/Juvix/Sexp/Structure.hs
+++ b/library/Translate/src/Juvix/Sexp/Structure.hs
@@ -232,6 +232,23 @@ data Declaim = Declaim
   }
   deriving (Show)
 
+-- | @DefModule@ - Stands in for a module declaration
+data DefModule = DefModule
+  { defModuleName :: Sexp.T,
+    defModuleArgs :: Sexp.T,
+    defModuleBody :: Sexp.T
+  }
+  deriving (Show)
+
+-- | @LefModule@ - Stands in for a module let declaration
+data LetModule = LetModule
+  { letModuleName :: Sexp.T,
+    letModuleArgs :: Sexp.T,
+    letModuleBody :: Sexp.T,
+    letModuleRest :: Sexp.T
+  }
+  deriving (Show)
+
 --------------------------------------------------------------------------------
 -- Converter functions
 -- The format for these are
@@ -969,3 +986,29 @@ toDeclaim form
 fromDeclaim :: Declaim -> Sexp.T
 fromDeclaim (Declaim sexp1 sexp2) =
   Sexp.list [Sexp.atom nameDeclaim, sexp1, sexp2]
+
+----------------------------------------
+-- DefModule
+----------------------------------------
+
+nameDefModule :: NameSymbol.T
+nameDefModule = ":defmodule"
+
+isDefModule :: Sexp.T -> Bool
+isDefModule (Sexp.Cons form _) = Sexp.isAtomNamed form nameDefModule
+isDefModule _ = False
+
+toDefModule :: Sexp.T -> Maybe DefModule
+toDefModule form
+  | isDefModule form =
+    case form of
+      _DefModule Sexp.:> sexp1 Sexp.:> sexp2 Sexp.:> sexp3 ->
+        DefModule sexp1 sexp2 sexp3 |> Just
+      _ ->
+        Nothing
+  | otherwise =
+    Nothing
+
+fromDefModule :: DefModule -> Sexp.T
+fromDefModule (DefModule sexp1 sexp2 sexp3) =
+  Sexp.listStar [Sexp.atom nameDefModule, sexp1, sexp2, sexp3]

--- a/library/Translate/src/Juvix/Sexp/Structure.hs
+++ b/library/Translate/src/Juvix/Sexp/Structure.hs
@@ -317,6 +317,7 @@ toArgBody form =
 fromArgBody :: ArgBody -> Sexp.T
 fromArgBody (ArgBody sexp1 sexp2) =
   Sexp.list [sexp1, sexp2]
+
 ----------------------------------------
 -- Type
 ----------------------------------------
@@ -342,6 +343,7 @@ toType form
 fromType :: Type -> Sexp.T
 fromType (Type sexp1 sexp2 sexp3) =
   Sexp.listStar [Sexp.atom nameType, sexp1, sexp2, sexp3]
+
 ----------------------------------------
 -- LetType
 ----------------------------------------
@@ -367,6 +369,7 @@ toLetType form
 fromLetType :: LetType -> Sexp.T
 fromLetType (LetType sexp1 sexp2 sexp3 sexp4) =
   Sexp.list [Sexp.atom nameLetType, sexp1, sexp2, sexp3, sexp4]
+
 ----------------------------------------
 -- Defun
 ----------------------------------------
@@ -392,6 +395,7 @@ toDefun form
 fromDefun :: Defun -> Sexp.T
 fromDefun (Defun sexp1 sexp2 sexp3) =
   Sexp.list [Sexp.atom nameDefun, sexp1, sexp2, sexp3]
+
 ----------------------------------------
 -- DefunMatch
 ----------------------------------------
@@ -418,6 +422,7 @@ toDefunMatch form
 fromDefunMatch :: DefunMatch -> Sexp.T
 fromDefunMatch (DefunMatch sexp1 argBody2) =
   Sexp.listStar [Sexp.atom nameDefunMatch, sexp1, fromArgBody `toStarList` argBody2]
+
 ----------------------------------------
 -- DefunSigMatch
 ----------------------------------------
@@ -444,6 +449,7 @@ toDefunSigMatch form
 fromDefunSigMatch :: DefunSigMatch -> Sexp.T
 fromDefunSigMatch (DefunSigMatch sexp1 sexp2 argBody3) =
   Sexp.listStar [Sexp.atom nameDefunSigMatch, sexp1, sexp2, fromArgBody `toStarList` argBody3]
+
 ----------------------------------------
 -- Signature
 ----------------------------------------
@@ -469,6 +475,7 @@ toSignature form
 fromSignature :: Signature -> Sexp.T
 fromSignature (Signature sexp1 sexp2) =
   Sexp.list [Sexp.atom nameSignature, sexp1, sexp2]
+
 ----------------------------------------
 -- LetSignature
 ----------------------------------------
@@ -494,6 +501,7 @@ toLetSignature form
 fromLetSignature :: LetSignature -> Sexp.T
 fromLetSignature (LetSignature sexp1 sexp2 sexp3) =
   Sexp.list [Sexp.atom nameLetSignature, sexp1, sexp2, sexp3]
+
 ----------------------------------------
 -- Let
 ----------------------------------------
@@ -519,6 +527,7 @@ toLet form
 fromLet :: Let -> Sexp.T
 fromLet (Let sexp1 sexp2 sexp3 sexp4) =
   Sexp.list [Sexp.atom nameLet, sexp1, sexp2, sexp3, sexp4]
+
 ----------------------------------------
 -- LetMatch
 ----------------------------------------
@@ -545,6 +554,7 @@ toLetMatch form
 fromLetMatch :: LetMatch -> Sexp.T
 fromLetMatch (LetMatch sexp1 argBodys2 sexp3) =
   Sexp.list [Sexp.atom nameLetMatch, sexp1, fromArgBodys argBodys2, sexp3]
+
 ----------------------------------------
 -- PredAns
 ----------------------------------------
@@ -560,6 +570,7 @@ toPredAns form =
 fromPredAns :: PredAns -> Sexp.T
 fromPredAns (PredAns sexp1 sexp2) =
   Sexp.list [sexp1, sexp2]
+
 ----------------------------------------
 -- Cond
 ----------------------------------------
@@ -586,6 +597,7 @@ toCond form
 fromCond :: Cond -> Sexp.T
 fromCond (Cond predAns1) =
   Sexp.listStar [Sexp.atom nameCond, fromPredAns `toStarList` predAns1]
+
 ----------------------------------------
 -- If
 ----------------------------------------
@@ -611,6 +623,7 @@ toIf form
 fromIf :: If -> Sexp.T
 fromIf (If sexp1 sexp2 sexp3) =
   Sexp.list [Sexp.atom nameIf, sexp1, sexp2, sexp3]
+
 ----------------------------------------
 -- IfNoElse
 ----------------------------------------
@@ -636,6 +649,7 @@ toIfNoElse form
 fromIfNoElse :: IfNoElse -> Sexp.T
 fromIfNoElse (IfNoElse sexp1 sexp2) =
   Sexp.list [Sexp.atom nameIfNoElse, sexp1, sexp2]
+
 ----------------------------------------
 -- DeconBody
 ----------------------------------------
@@ -651,6 +665,7 @@ toDeconBody form =
 fromDeconBody :: DeconBody -> Sexp.T
 fromDeconBody (DeconBody sexp1 sexp2) =
   Sexp.list [sexp1, sexp2]
+
 ----------------------------------------
 -- Case
 ----------------------------------------
@@ -677,6 +692,7 @@ toCase form
 fromCase :: Case -> Sexp.T
 fromCase (Case sexp1 deconBody2) =
   Sexp.listStar [Sexp.atom nameCase, sexp1, fromDeconBody `toStarList` deconBody2]
+
 ----------------------------------------
 -- Do
 ----------------------------------------
@@ -702,6 +718,7 @@ toDo form
 fromDo :: Do -> Sexp.T
 fromDo (Do sexp1) =
   Sexp.listStar [Sexp.atom nameDo, sexp1]
+
 ----------------------------------------
 -- Arrow
 ----------------------------------------
@@ -727,6 +744,7 @@ toArrow form
 fromArrow :: Arrow -> Sexp.T
 fromArrow (Arrow sexp1 sexp2) =
   Sexp.list [Sexp.atom nameArrow, sexp1, sexp2]
+
 ----------------------------------------
 -- Lambda
 ----------------------------------------
@@ -752,6 +770,7 @@ toLambda form
 fromLambda :: Lambda -> Sexp.T
 fromLambda (Lambda sexp1 sexp2) =
   Sexp.list [Sexp.atom nameLambda, sexp1, sexp2]
+
 ----------------------------------------
 -- Punned
 ----------------------------------------
@@ -767,6 +786,7 @@ toPunned form =
 fromPunned :: Punned -> Sexp.T
 fromPunned (Punned sexp1) =
   Sexp.list [sexp1]
+
 ----------------------------------------
 -- NotPunned
 ----------------------------------------
@@ -782,6 +802,7 @@ toNotPunned form =
 fromNotPunned :: NotPunned -> Sexp.T
 fromNotPunned (NotPunned sexp1 sexp2) =
   Sexp.list [sexp1, sexp2]
+
 ----------------------------------------
 -- Record
 ----------------------------------------
@@ -808,6 +829,7 @@ toRecord form
 fromRecord :: Record -> Sexp.T
 fromRecord (Record nameBind1) =
   Sexp.listStar [Sexp.atom nameRecord, fromNameBind `toStarList` nameBind1]
+
 ----------------------------------------
 -- RecordNoPunned
 ----------------------------------------
@@ -834,6 +856,7 @@ toRecordNoPunned form
 fromRecordNoPunned :: RecordNoPunned -> Sexp.T
 fromRecordNoPunned (RecordNoPunned notPunnedGroup1) =
   Sexp.listStar [Sexp.atom nameRecordNoPunned, fromNotPunnedGroup notPunnedGroup1]
+
 ----------------------------------------
 -- Infix
 ----------------------------------------
@@ -859,6 +882,7 @@ toInfix form
 fromInfix :: Infix -> Sexp.T
 fromInfix (Infix sexp1 sexp2 sexp3) =
   Sexp.list [Sexp.atom nameInfix, sexp1, sexp2, sexp3]
+
 ----------------------------------------
 -- OpenIn
 ----------------------------------------
@@ -884,6 +908,7 @@ toOpenIn form
 fromOpenIn :: OpenIn -> Sexp.T
 fromOpenIn (OpenIn sexp1 sexp2) =
   Sexp.list [Sexp.atom nameOpenIn, sexp1, sexp2]
+
 ----------------------------------------
 -- Open
 ----------------------------------------
@@ -909,6 +934,7 @@ toOpen form
 fromOpen :: Open -> Sexp.T
 fromOpen (Open sexp1) =
   Sexp.list [Sexp.atom nameOpen, sexp1]
+
 ----------------------------------------
 -- Declare
 ----------------------------------------
@@ -934,6 +960,7 @@ toDeclare form
 fromDeclare :: Declare -> Sexp.T
 fromDeclare (Declare sexp1) =
   Sexp.list [Sexp.atom nameDeclare, sexp1]
+
 ----------------------------------------
 -- Declaim
 ----------------------------------------
@@ -959,6 +986,7 @@ toDeclaim form
 fromDeclaim :: Declaim -> Sexp.T
 fromDeclaim (Declaim sexp1 sexp2) =
   Sexp.list [Sexp.atom nameDeclaim, sexp1, sexp2]
+
 ----------------------------------------
 -- DefModule
 ----------------------------------------
@@ -984,6 +1012,7 @@ toDefModule form
 fromDefModule :: DefModule -> Sexp.T
 fromDefModule (DefModule sexp1 sexp2 sexp3) =
   Sexp.listStar [Sexp.atom nameDefModule, sexp1, sexp2, sexp3]
+
 ----------------------------------------
 -- LetModule
 ----------------------------------------

--- a/library/Translate/src/Juvix/Sexp/Structure/Lens.hs
+++ b/library/Translate/src/Juvix/Sexp/Structure/Lens.hs
@@ -36,3 +36,4 @@ Lens.makeLensesWith Lens.camelCaseFields ''Type
 Lens.makeLensesWith Lens.camelCaseFields ''LetType
 Lens.makeLensesWith Lens.camelCaseFields ''LetSignature
 Lens.makeLensesWith Lens.camelCaseFields ''DefModule
+Lens.makeLensesWith Lens.camelCaseFields ''LetModule

--- a/library/Translate/src/Juvix/Sexp/Structure/Lens.hs
+++ b/library/Translate/src/Juvix/Sexp/Structure/Lens.hs
@@ -35,3 +35,4 @@ Lens.makeLensesWith Lens.camelCaseFields ''Declaim
 Lens.makeLensesWith Lens.camelCaseFields ''Type
 Lens.makeLensesWith Lens.camelCaseFields ''LetType
 Lens.makeLensesWith Lens.camelCaseFields ''LetSignature
+Lens.makeLensesWith Lens.camelCaseFields ''DefModule

--- a/library/Translate/src/Juvix/Sexp/Structure/Lens.hs
+++ b/library/Translate/src/Juvix/Sexp/Structure/Lens.hs
@@ -29,3 +29,6 @@ Lens.makeLensesWith Lens.camelCaseFields ''NotPunned
 Lens.makeLensesWith Lens.camelCaseFields ''RecordNoPunned
 Lens.makeLensesWith Lens.camelCaseFields ''Infix
 Lens.makeLensesWith Lens.camelCaseFields ''OpenIn
+Lens.makeLensesWith Lens.camelCaseFields ''Open
+Lens.makeLensesWith Lens.camelCaseFields ''Declare
+Lens.makeLensesWith Lens.camelCaseFields ''Declaim

--- a/library/Translate/src/Juvix/Sexp/Structure/Lens.hs
+++ b/library/Translate/src/Juvix/Sexp/Structure/Lens.hs
@@ -32,3 +32,6 @@ Lens.makeLensesWith Lens.camelCaseFields ''OpenIn
 Lens.makeLensesWith Lens.camelCaseFields ''Open
 Lens.makeLensesWith Lens.camelCaseFields ''Declare
 Lens.makeLensesWith Lens.camelCaseFields ''Declaim
+Lens.makeLensesWith Lens.camelCaseFields ''Type
+Lens.makeLensesWith Lens.camelCaseFields ''LetType
+Lens.makeLensesWith Lens.camelCaseFields ''LetSignature

--- a/library/Translate/src/Juvix/Sexp/Structure/Lens.hs
+++ b/library/Translate/src/Juvix/Sexp/Structure/Lens.hs
@@ -27,3 +27,5 @@ Lens.makeLensesWith Lens.camelCaseFields ''Record
 Lens.makeLensesWith Lens.camelCaseFields ''Punned
 Lens.makeLensesWith Lens.camelCaseFields ''NotPunned
 Lens.makeLensesWith Lens.camelCaseFields ''RecordNoPunned
+Lens.makeLensesWith Lens.camelCaseFields ''Infix
+Lens.makeLensesWith Lens.camelCaseFields ''OpenIn

--- a/library/Translate/src/Juvix/Sexp/generator.lisp
+++ b/library/Translate/src/Juvix/Sexp/generator.lisp
@@ -326,4 +326,4 @@ and a rhs that may contain a guard, so no = is assumed for the rhs"
 
 (generate-haskell "DefModule" (repeat 3 "sexp") ":defmodule" :list-star t)
 
-(generate-haskell "DefModule" (repeat 3 "sexp") ":defmodule" :list-star t)
+(generate-haskell "LetModule" (repeat 4 "sexp") ":let-mod")

--- a/library/Translate/src/Juvix/Sexp/generator.lisp
+++ b/library/Translate/src/Juvix/Sexp/generator.lisp
@@ -201,7 +201,7 @@ and a rhs that may contain a guard, so no = is assumed for the rhs"
                        pat names))
              (match (names)
                (format nil "~{~a~^ Sexp.:> ~}"
-                       (append (when s-name (list (format nil "_~a" con-name)))
+                       (append (when s-name (list (format nil "_name~a" con-name)))
                                names
                                (unless list-star '("Sexp.Nil")))))
              (from-construction (pat names)

--- a/library/Translate/src/Juvix/Sexp/generator.lisp
+++ b/library/Translate/src/Juvix/Sexp/generator.lisp
@@ -307,3 +307,7 @@ and a rhs that may contain a guard, so no = is assumed for the rhs"
 (generate-haskell "RecordNoPunned" '("notPunnedGroup") ":record-no-pun"
                   :list-star t
                   :un-grouped t)
+
+(generate-haskell "Infix" (repeat 3 "sexp") ":infix")
+
+(generate-haskell "OpenIn" (repeat 2 "sexp") ":open-in")

--- a/library/Translate/src/Juvix/Sexp/generator.lisp
+++ b/library/Translate/src/Juvix/Sexp/generator.lisp
@@ -323,3 +323,7 @@ and a rhs that may contain a guard, so no = is assumed for the rhs"
 (generate-haskell "Declare" '("sexp") "declare")
 
 (generate-haskell "Declaim" (repeat 2 "sexp") ":declaim")
+
+(generate-haskell "DefModule" (repeat 3 "sexp") ":defmodule" :list-star t)
+
+(generate-haskell "DefModule" (repeat 3 "sexp") ":defmodule" :list-star t)

--- a/library/Translate/src/Juvix/Sexp/generator.lisp
+++ b/library/Translate/src/Juvix/Sexp/generator.lisp
@@ -265,6 +265,10 @@ and a rhs that may contain a guard, so no = is assumed for the rhs"
 
 (generate-haskell "ArgBody" '("sexp" "sexp") nil)
 
+(generate-haskell "Type" (repeat 3 "sexp") "type" :list-star t)
+
+(generate-haskell "LetType" (repeat 4 "sexp") "let-type")
+
 (generate-haskell "Defun" '("sexp" "sexp" "sexp") ":defun")
 
 (generate-haskell "DefunMatch" '("sexp" "argBody") ":defun-match" :list-star t)
@@ -272,6 +276,8 @@ and a rhs that may contain a guard, so no = is assumed for the rhs"
 (generate-haskell "DefunSigMatch" '("sexp" "sexp" "argBody") ":defsig-match" :list-star t)
 
 (generate-haskell "Signature" '("sexp" "sexp") ":defsig")
+
+(generate-haskell "LetSignature" (repeat 3 "sexp") ":let-sig")
 
 (generate-haskell "Let" (repeat 4 "sexp") "let")
 

--- a/library/Translate/src/Juvix/Sexp/generator.lisp
+++ b/library/Translate/src/Juvix/Sexp/generator.lisp
@@ -267,7 +267,7 @@ and a rhs that may contain a guard, so no = is assumed for the rhs"
 
 (generate-haskell "Type" (repeat 3 "sexp") "type" :list-star t)
 
-(generate-haskell "LetType" (repeat 4 "sexp") "let-type")
+(generate-haskell "LetType" (repeat 4 "sexp") ":let-type")
 
 (generate-haskell "Defun" '("sexp" "sexp" "sexp") ":defun")
 

--- a/library/Translate/src/Juvix/Sexp/generator.lisp
+++ b/library/Translate/src/Juvix/Sexp/generator.lisp
@@ -311,3 +311,9 @@ and a rhs that may contain a guard, so no = is assumed for the rhs"
 (generate-haskell "Infix" (repeat 3 "sexp") ":infix")
 
 (generate-haskell "OpenIn" (repeat 2 "sexp") ":open-in")
+
+(generate-haskell "Open" '("sexp") "open")
+
+(generate-haskell "Declare" '("sexp") "declare")
+
+(generate-haskell "Declaim" (repeat 2 "sexp") ":declaim")

--- a/library/Translate/test/Test/Desugar/Sexp.hs
+++ b/library/Translate/test/Test/Desugar/Sexp.hs
@@ -258,4 +258,4 @@ modLetWorkAsExpected =
         \         (let bar () 3 \
         \            (:let-type foo () ((XTZ))\
         \               (:record (bar) (foo))))\
-        \     (foo)))"
+        \     foo))"

--- a/library/Translate/test/Test/Desugar/Sexp.hs
+++ b/library/Translate/test/Test/Desugar/Sexp.hs
@@ -195,7 +195,10 @@ modulesWorkAsExpected =
     "module desugar tests"
     [ T.testCase
         "basic expnasion expansion work"
-        (expected T.@=? fmap Desugar.moduleTransform form)
+        (expected T.@=? fmap Desugar.moduleTransform form),
+      T.testCase
+        "Type expansion works"
+        (expectedComplicated T.@=? fmap Desugar.moduleTransform formComplicated)
     ]
   where
     form =
@@ -213,6 +216,25 @@ modulesWorkAsExpected =
         \                           (Snash))\
         \         (let fi () 3\
         \            (:record (b) (bazzz) (fi))))))"
+
+    formComplicated =
+      Sexp.parse
+      "(:defmodule f ()\
+        \    (:defmodule b ()\
+        \       (:defun a () 2))\
+        \    (type bazzz () (Foo (:record-d a int b int)) (Snash))\
+        \    (type (foo :type (:infix -> typ (:infix -> typ typ))) (x y z)\
+        \       (Foo a b c))\
+        \    (:defun fi () 3))"
+    expectedComplicated =
+      Sexp.parse
+        "(:defun f ()\
+        \   (:let-mod b () ((:defun a () 2))\
+        \      (:let-type bazzz (() (Foo (:record-d a int b int))\
+        \                           (Snash))\
+        \ (:let-type (foo :type (:infix -> typ (:infix -> typ typ))) \
+        \            ((x y z) (Foo a b c))\
+        \    (let fi () 3 (:record (b) (bazzz) (fi) (foo)))))))"
 
 modLetWorkAsExpected :: T.TestTree
 modLetWorkAsExpected =

--- a/library/Translate/test/Test/Desugar/Sexp.hs
+++ b/library/Translate/test/Test/Desugar/Sexp.hs
@@ -212,7 +212,7 @@ modulesWorkAsExpected =
       Sexp.parse
         "(:defun f ()\
         \   (:let-mod b () ((:defun a () 2))\
-        \      (:let-type bazzz (() (Foo (:record-d a int b int))\
+        \      (:let-type bazzz () ((Foo (:record-d a int b int))\
         \                           (Snash))\
         \         (let fi () 3\
         \            (:record (b) (bazzz) (fi))))))"
@@ -230,10 +230,10 @@ modulesWorkAsExpected =
       Sexp.parse
         "(:defun f ()\
         \   (:let-mod b () ((:defun a () 2))\
-        \      (:let-type bazzz (() (Foo (:record-d a int b int))\
+        \      (:let-type bazzz () ((Foo (:record-d a int b int))\
         \                           (Snash))\
         \ (:let-type (foo :type (:infix -> typ (:infix -> typ typ))) \
-        \            ((x y z) (Foo a b c))\
+        \            (x y z) ((Foo a b c))\
         \    (let fi () 3 (:record (b) (bazzz) (fi) (foo)))))))"
 
 modLetWorkAsExpected :: T.TestTree
@@ -256,6 +256,6 @@ modLetWorkAsExpected =
         "(:defun foo ()\
         \   (let foo ()\
         \         (let bar () 3 \
-        \            (:let-type foo (() (XTZ))\
+        \            (:let-type foo () ((XTZ))\
         \               (:record (bar) (foo))))\
         \     (foo)))"

--- a/library/Translate/test/Test/Desugar/Sexp.hs
+++ b/library/Translate/test/Test/Desugar/Sexp.hs
@@ -219,7 +219,7 @@ modulesWorkAsExpected =
 
     formComplicated =
       Sexp.parse
-      "(:defmodule f ()\
+        "(:defmodule f ()\
         \    (:defmodule b ()\
         \       (:defun a () 2))\
         \    (type bazzz () (Foo (:record-d a int b int)) (Snash))\


### PR DESCRIPTION
We should not be matching on the S-expression sturcture directly as we did in this file, this pr fixes that mistake.

Finishing the rest of Desugar will also be in the PR, in the second commit.