### PR TITLE
Extend context correctly when typechecking Π

### DIFF
--- a/ChangeLog.org
+++ b/ChangeLog.org
@@ -1,5 +1,8 @@
 * Changelog for Juvix
 
+** 0.1.0.7
+  + Fix checking of Π types
+
 ** 0.1.0.6
   + Add Golden tests
 

--- a/library/Core/src/Juvix/Core/IR/CheckTerm.hs
+++ b/library/Core/src/Juvix/Core/IR/CheckTerm.hs
@@ -136,7 +136,8 @@ typeTerm' term ann@(Annotation σ ty) =
       requireZero σ
       void $ requireStar ty
       a' <- typeTerm' a ann
-      b' <- typeTerm' b ann
+      av <- evalTC a'
+      b' <- withLocal (Annotation mempty av) $ typeTerm' b ann
       pure $ Typed.Pi π a' b' ann
     IR.Lam' t _ -> do
       (π, a, b) <- requirePi ty

--- a/library/Core/test/Typechecker.hs
+++ b/library/Core/test/Typechecker.hs
@@ -284,12 +284,24 @@ dependentFunctionComp =
         depIdentityCompTy,
       shouldCheck
         All.t
+        depIdentity'
+        depIdentityCompTy,
+      shouldCheck
+        All.t
         depIdentity
         depIdentityCompTyOmega,
       shouldCheck
         All.t
         depK
-        depKCompTy
+        depKCompTy,
+      shouldCheck
+        All.t
+        depIdentityCompTyT
+        (mempty `ann` IR.VStar 1),
+      shouldCheck
+        All.t
+        depKCompTyT
+        (mempty `ann` IR.VStar 1)
     ]
 
 letComp :: T.TestTree
@@ -390,6 +402,18 @@ depIdentity =
             )
         )
     )
+
+-- dependent identity function without ann, \t.\x.x
+depIdentity' :: forall primTy primVal. IR.Term primTy primVal
+depIdentity' = IR.Lam $ IR.Lam $ IR.Elim $ IR.Bound 0
+
+-- computation dependent identity annotation (1, 0 * -> 1 t -> t)
+depIdentityCompTyT :: AllTerm
+depIdentityCompTyT =
+  IR.Pi mempty (IR.Star 0) $
+    IR.Pi one (IR.Elim $ IR.Bound 0) $
+      IR.Elim $ IR.Bound 1
+
 
 -- computation dependent identity annotation (1, 0 * -> 1 t -> t)
 depIdentityCompTy :: AllAnnotation
@@ -702,6 +726,15 @@ depKCompTy =
               )
           )
       )
+
+depKCompTyT :: AllTerm
+depKCompTyT =
+  IR.Pi mempty (IR.Star 0) $
+    IR.Pi mempty (IR.Star 0) $
+      IR.Pi one (IR.Elim $ IR.Bound 1) $
+        IR.Pi mempty (IR.Elim $ IR.Bound 1) $
+          IR.Elim $ IR.Bound 3
+
 
 -- S combinator: Sxyz = xz(yz)
 -- Because S returns functions, it's not general because of the annotations.

--- a/library/Core/test/Typechecker.hs
+++ b/library/Core/test/Typechecker.hs
@@ -414,7 +414,6 @@ depIdentityCompTyT =
     IR.Pi one (IR.Elim $ IR.Bound 0) $
       IR.Elim $ IR.Bound 1
 
-
 -- computation dependent identity annotation (1, 0 * -> 1 t -> t)
 depIdentityCompTy :: AllAnnotation
 depIdentityCompTy =
@@ -734,7 +733,6 @@ depKCompTyT =
       IR.Pi one (IR.Elim $ IR.Bound 1) $
         IR.Pi mempty (IR.Elim $ IR.Bound 1) $
           IR.Elim $ IR.Bound 3
-
 
 -- S combinator: Sxyz = xz(yz)
 -- Because S returns functions, it's not general because of the annotations.


### PR DESCRIPTION
Fixes #799.