### PR TITLE
Add ghc profiling output to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 */.stack-work/
 *.hie
 *.cabal
+*.prof
 
 # Juvix temporary
 juvix.yaml


### PR DESCRIPTION
Profiling with `ghc` (such as by using the `--profile` option to the `stack` command) generates `.prof` files, which we should not commit.